### PR TITLE
Add Vibe Compiler (vibec) to Command Line Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ English | [한국어](./README-KR.md)
 - [anthropics/claude-code](https://github.com/anthropics/claude-code) - Coding agent that understands your codebase, automates tasks, explains code, and manages git, all via natural language.
 - [aider](https://aider.chat/) - AI pair programming in your terminal.
 - [codename goose](https://block.github.io/goose/) - Local, on-machine AI Agent that allows you to use any LLM and add any MCP servers as extensions
+- [Vibe Compiler (vibec)](https://github.com/grishingrishin/vibe-compiler) - A self-compiling tool that transforms markdown-based prompt stacks into code and tests using LLM generation. Works with any LLM via OpenRouter, including Claude, ChatGPT, and Grok.
 - [MyCoder.ai](https://github.com/drivecore/mycoder) - Open source AI-powered coding assistant with Git and GitHub integration, featuring parallel execution and self-modification capabilities.
 - [ai-christianson/RA.Aid](https://github.com/ai-christianson/RA.Aid) - A standalone coding agent built on LangGraph's agent-based task execution framework
 - [CodeSelect](https://github.com/maynetee/codeselect) - A Python-based command-line tool that efficiently communicates project source code to AIs.


### PR DESCRIPTION
This PR adds Vibe Compiler (vibec) to the Command Line Tools section. Vibe Compiler is a self-compiling tool that transforms markdown-based prompt stacks into code and tests using LLM generation via OpenRouter (including Claude, ChatGPT, and Grok).