### PR TITLE
docs: add chinese and japanese translations for README

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -1,0 +1,109 @@
+# Awesome Vibe Coding [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) <!-- omit in toc -->
+
+> 精选的氛围编程参考资源列表，与AI协作编写代码。
+
+[English](./README.md) | [한국어](./README-KR.md) | 中文 | [日本語](./README-JP.md)
+
+## 目录 <!-- omit in toc -->
+
+- [关于概念](#关于概念)
+- [基于浏览器的工具](#基于浏览器的工具)
+- [IDE和代码编辑器](#ide和代码编辑器)
+- [移动应用](#移动应用)
+- [插件和扩展](#插件和扩展)
+- [本地应用](#本地应用)
+- [命令行工具](#命令行工具)
+- [AI编程任务管理](#ai编程任务管理)
+- [AI编程文档](#ai编程文档)
+- [新闻和社交媒体](#新闻和社交媒体)
+- [贡献](#贡献)
+
+## 关于概念
+
+- [Andrej Karpathy on X](https://x.com/karpathy/status/1886192184808149383) - "有一种新的编程方式，我称之为'氛围编程'，你完全沉浸在氛围中，拥抱指数级增长，甚至忘记代码的存在。(.) 我在构建项目或网络应用，但这不是真正的编程——我只是看东西、说东西、运行东西、复制粘贴东西，而且大部分时候都能正常工作"。
+- [automata/aicodeguide](https://github.com/automata/aicodeguide) - 开始使用AI编程的路线图。
+
+## 基于浏览器的工具
+
+- 🔥 [Bolt.new](https://bolt.new/) - 提示、运行、编辑和部署全栈Web和移动应用。
+- 🔥 [Lovable](https://lovable.dev/) - "几秒钟从想法到应用。Lovable是你的超人全栈工程师"。
+- 🔥 [v0 by Vercel](https://v0.dev/chat) - 构建NextJS前端的助手。
+- 🔥 [CHAI.new by Langbase](https://chai.new) - 提示氛围编程任何AI代理并部署（代理、应用、API）
+- [Replit](https://replit.com/) - "只需在上方描述你的想法，让代理为你构建"。
+- [Create](https://www.create.xyz/) - "将你的想法转化为网站、工具、应用和产品"。
+- [Trickle AI](https://www.trickle.so/) - "轻松构建令人惊艳的网站、AI应用和表单"。
+- [Tempo](https://www.tempo.new/) - "使用AI构建React应用快10倍"。
+- [Softgen](https://softgen.ai/) - "描述你的愿景，给出指令，构建全栈Web应用"。
+- [Lazy AI](https://getlazy.ai/) - "使用提示构建可靠的商业应用"。
+- [HeyBoss](https://www.heyboss.xyz/) - "几分钟内构建应用和网站"。
+- [Creatr](https://getcreatr.com/) - "几秒钟内创建和部署Web应用和着陆页"。
+- [Rork](https://rork.app/) - "快速构建任何移动应用"。
+- [Firebase Studio](https://studio.firebase.google.com/) - Google的代理云开发环境，帮助构建和发布生产级全栈AI应用。
+- [Napkins.dev](https://www.napkins.dev/) - 截图转代码
+- [HeroUI Chat](https://heroui.chat/) - 无论你的设计经验如何，都能生成美丽的应用。
+
+## IDE和代码编辑器
+
+- [Windsurf Editor by Codeium](https://codeium.com/windsurf) - 代理IDE，"开发者和AI真正协同工作的地方，提供如魔法般的编程体验"。
+- 🔥 [Cursor](https://www.cursor.com/) - AI代码编辑器，"使用AI编程的最佳方式"。
+- [Zed](https://zed.dev/) - 专为与人类和AI高性能协作而设计的代码编辑器。
+
+## 移动应用
+
+- [VibeCode](https://www.vibecodeapp.com/) - 构建应用的应用。
+
+## 插件和扩展
+
+- [Cline](https://cline.bot/) - 可以使用你的CLI和编辑器的AI助手，适用于VS Code。
+- [Roo Code](https://github.com/RooVetGit/Roo-Code) - cline的分支，具有额外功能/增强
+- [avante.nvim](https://github.com/yetone/avante.nvim) - 旨在模拟Cursor AI IDE行为的Neovim插件。它提供AI驱动的代码建议，让你能够以最小的努力将推荐直接应用到源文件中。
+- [backnotprop/prompt-tower](https://github.com/backnotprop/prompt-tower) - 帮助你构建包含多个代码块的提示的工具。
+- [Augment Code](https://www.augmentcode.com/) - 为专业软件工程师和大型代码库构建的AI编程助手。
+- [continuedev/continue](https://github.com/continuedev/continue): 使用我们的开源IDE扩展和模型、提示、规则和文档库构建、共享和使用自定义AI代码助手。
+- [GitHub Copilot](https://github.com/features/copilot) - 旨在帮助你在Visual Studio Code中更快编程的AI。它提供代码补全、与AI模型聊天和代理编程的代理模式
+
+## 本地应用
+- [Dyad](https://www.dyad.sh/) - 免费、本地、开源的AI应用构建器
+
+## 命令行工具
+
+- [anthropics/claude-code](https://github.com/anthropics/claude-code) - 理解你的代码库、自动化任务、解释代码和管理git的编程代理，全部通过自然语言。
+- [aider](https://aider.chat/) - 在终端中进行AI结对编程。
+- [codename goose](https://block.github.io/goose/) - 本地机器AI代理，允许你使用任何LLM并添加任何MCP服务器作为扩展
+- [MyCoder.ai](https://github.com/drivecore/mycoder) - 开源AI驱动的编程助手，具有Git和GitHub集成，支持并行执行和自修改功能。
+- [ai-christianson/RA.Aid](https://github.com/ai-christianson/RA.Aid) - 基于LangGraph代理任务执行框架构建的独立编程代理
+- [CodeSelect](https://github.com/maynetee/codeselect) - 基于Python的命令行工具，高效地将项目源代码传达给AI。
+- [OpenAI Codex CLI](https://github.com/openai/codex) - OpenAI的轻量级编程代理，在终端中运行
+
+## AI编程任务管理
+
+- [Boomerang Tasks](https://docs.roocode.com/features/boomerang-tasks) - 自动将复杂项目分解为更小、可管理的部分。
+- [Claude Task Master](https://github.com/eyaltoledano/claude-task-master) - 可以集成到Cursor、Lovable、Windsurf、Roo等工具中的AI驱动任务管理系统。
+
+## AI编程文档
+
+- [CodeGuide](https://www.codeguide.dev/) - 为你的AI编程项目创建详细文档。
+
+## 新闻和社交媒体
+
+> 本节按时间倒序显示项目，最新条目在顶部。
+
+- [Peer Programming with LLMs, For Senior+ Engineers](https://pmbanugo.me/blog/peer-programming-with-llms)
+- 🔥 [The Way of Code | Rick Rubin](https://www.thewayofcode.com/)
+- [The State of Vibe Coding Tools (May 2025) | LinkedIn](https://www.linkedin.com/pulse/state-vibe-coding-tools-may-2025-nufar-gaspar-x1znf/?trackingId=iJSsdxE4R9OECPT43FtBww%3D%3D)
+- [Vibe coding MenuGen | karpathy](https://karpathy.bearblog.dev/vibe-coding-menugen/)
+- [Two publishers and three authors fail to understand what "vibe coding" means](https://simonwillison.net/2025/May/1/not-vibe-coding/)
+- [Not all AI-assisted programming is vibe coding (but vibe coding rocks)](https://simonwillison.net/2025/Mar/19/vibe-coding/)
+- [Vibe Coding 101 with Replit - DeepLearning.AI](https://www.deeplearning.ai/short-courses/vibe-coding-101-with-replit/)
+- [The "vibe coding" mind virus explained… by Fireship - YouTube](https://www.youtube.com/watch?v=Tw18-4U7mts)
+- [Not all AI-assisted programming is vibe coding (but vibe coding rocks)](https://simonwillison.net/2025/Mar/19/vibe-coding/)
+- [bolt.new on X - "Introducing Figma to Bolt Go from Figma to pixel-perfect full stack app - X](https://x.com/boltdotnew/status/1900197121829331158)
+- [Will the future of software development run on vibes? - Ars Technica](https://arstechnica.com/ai/2025/03/is-vibe-coding-with-ai-gnarly-or-reckless-maybe-some-of-both/)
+- [Vibe Coding - Where Everyone Can 'Speak' Computer Programming - The New Stack](https://thenewstack.io/vibe-coding-where-everyone-can-speak-computer-programming/)
+- [A.I. and Vibecoding Helped Me to Create My Own Software - The New York Times](https://www.nytimes.com/2025/02/27/technology/personaltech/vibecoding-ai-software-programming.html)
+- [/r/vibecoding](https://www.reddit.com/r/vibecoding/)
+- [/r/ChatGPTCoding](https://www.reddit.com/r/ChatGPTCoding/)
+
+## 贡献
+
+欢迎贡献！请先阅读[贡献指南](CONTRIBUTING.md)。

--- a/README-JP.md
+++ b/README-JP.md
@@ -1,0 +1,109 @@
+# Awesome Vibe Coding [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) <!-- omit in toc -->
+
+> AIと協力してコードを書く、バイブコーディングリファレンスの厳選リスト。
+
+[English](./README.md) | [한국어](./README-KR.md) | [中文](./README-CN.md) | 日本語
+
+## 目次 <!-- omit in toc -->
+
+- [概念について](#概念について)
+- [ブラウザベースツール](#ブラウザベースツール)
+- [IDEとコードエディタ](#ideとコードエディタ)
+- [モバイルアプリ](#モバイルアプリ)
+- [プラグインと拡張機能](#プラグインと拡張機能)
+- [ローカルアプリ](#ローカルアプリ)
+- [コマンドラインツール](#コマンドラインツール)
+- [AIコーディングタスク管理](#aiコーディングタスク管理)
+- [AIコーディングドキュメント](#aiコーディングドキュメント)
+- [ニュースとソーシャルメディア](#ニュースとソーシャルメディア)
+- [貢献](#貢献)
+
+## 概念について
+
+- [Andrej Karpathy on X](https://x.com/karpathy/status/1886192184808149383) - 「『バイブコーディング』と呼ぶ新しいコーディング方法があります。完全にバイブに身を委ね、指数関数的成長を受け入れ、コードの存在すら忘れてしまうのです。(.) プロジェクトやWebアプリを構築していますが、それは本当のコーディングではありません - ただ見て、話して、実行して、コピペするだけで、ほとんどうまくいくのです」。
+- [automata/aicodeguide](https://github.com/automata/aicodeguide) - AIでコーディングを始めるためのロードマップ。
+
+## ブラウザベースツール
+
+- 🔥 [Bolt.new](https://bolt.new/) - プロンプト、実行、編集、フルスタックWebおよびモバイルアプリのデプロイ。
+- 🔥 [Lovable](https://lovable.dev/) - 「アイデアから数秒でアプリに。Lovableはあなたの超人的なフルスタックエンジニアです」。
+- 🔥 [v0 by Vercel](https://v0.dev/chat) - NextJSフロントエンド構築アシスタント。
+- 🔥 [CHAI.new by Langbase](https://chai.new) - 任意のAIエージェントをバイブコーディングしてデプロイ（エージェント、アプリ、API）
+- [Replit](https://replit.com/) - 「上記にアイデアを説明するだけで、エージェントがあなたのために構築します」。
+- [Create](https://www.create.xyz/) - 「言葉をサイト、ツール、アプリ、製品に変換」。
+- [Trickle AI](https://www.trickle.so/) - 「美しいWebサイト、AIアプリ、フォームを簡単に構築」。
+- [Tempo](https://www.tempo.new/) - 「AIでReactアプリを10倍速く構築」。
+- [Softgen](https://softgen.ai/) - 「ビジョンを説明し、指示を与え、フルスタックWebアプリを構築」。
+- [Lazy AI](https://getlazy.ai/) - 「プロンプトで信頼性の高いビジネスアプリを構築」。
+- [HeyBoss](https://www.heyboss.xyz/) - 「数分でアプリとサイトを構築」。
+- [Creatr](https://getcreatr.com/) - 「数秒でWebアプリとランディングページを作成・デプロイ」。
+- [Rork](https://rork.app/) - 「あらゆるモバイルアプリを高速構築」。
+- [Firebase Studio](https://studio.firebase.google.com/) - 本格的なフルスタックAIアプリの構築と出荷を支援するGoogleのエージェンティッククラウド開発環境。
+- [Napkins.dev](https://www.napkins.dev/) - スクリーンショットからコードへ
+- [HeroUI Chat](https://heroui.chat/) - デザイン経験に関係なく美しいアプリを生成。
+
+## IDEとコードエディタ
+
+- [Windsurf Editor by Codeium](https://codeium.com/windsurf) - エージェンティックIDE、「開発者とAIが真に連携し、文字通り魔法のようなコーディング体験を可能にする場所」。
+- 🔥 [Cursor](https://www.cursor.com/) - AIコードエディタ、「AIでコーディングする最良の方法」。
+- [Zed](https://zed.dev/) - 人間とAIとの高性能コラボレーション用に設計されたコードエディタ。
+
+## モバイルアプリ
+
+- [VibeCode](https://www.vibecodeapp.com/) - アプリを構築するアプリ。
+
+## プラグインと拡張機能
+
+- [Cline](https://cline.bot/) - CLIとエディタを使用できるAIアシスタント、VS Code用。
+- [Roo Code](https://github.com/RooVetGit/Roo-Code) - 追加機能/拡張を持つclineのフォーク
+- [avante.nvim](https://github.com/yetone/avante.nvim) - Cursor AI IDEの動作を模倣するように設計されたNeovimプラグイン。AI駆動のコード提案を提供し、最小限の労力で推奨事項をソースファイルに直接適用できます。
+- [backnotprop/prompt-tower](https://github.com/backnotprop/prompt-tower) - 多くのコードブロックを含むプロンプトの構築を支援するツール。
+- [Augment Code](https://www.augmentcode.com/) - プロフェッショナルなソフトウェアエンジニアと大規模コードベース向けに構築されたAIコーディングアシスタント。
+- [continuedev/continue](https://github.com/continuedev/continue): オープンソースIDE拡張機能とモデル、プロンプト、ルール、ドキュメントのライブラリを使用してカスタムAIコードアシスタントを構築、共有、使用。
+- [GitHub Copilot](https://github.com/features/copilot) - Visual Studio Codeでより速くコーディングするのを支援するように設計されたAI。コード補完、AIモデルとのチャット、エージェンティックコーディング用のエージェントモードを提供
+
+## ローカルアプリ
+- [Dyad](https://www.dyad.sh/) - 無料、ローカル、オープンソースのAIアプリビルダー
+
+## コマンドラインツール
+
+- [anthropics/claude-code](https://github.com/anthropics/claude-code) - コードベースを理解し、タスクを自動化し、コードを説明し、gitを管理するコーディングエージェント、すべて自然言語で。
+- [aider](https://aider.chat/) - ターミナルでのAIペアプログラミング。
+- [codename goose](https://block.github.io/goose/) - 任意のLLMを使用し、任意のMCPサーバーを拡張として追加できるローカルマシンAIエージェント
+- [MyCoder.ai](https://github.com/drivecore/mycoder) - GitとGitHub統合、並列実行と自己修正機能を備えたオープンソースAI駆動コーディングアシスタント。
+- [ai-christianson/RA.Aid](https://github.com/ai-christianson/RA.Aid) - LangGraphのエージェントベースタスク実行フレームワーク上に構築されたスタンドアロンコーディングエージェント
+- [CodeSelect](https://github.com/maynetee/codeselect) - プロジェクトソースコードをAIに効率的に伝達するPythonベースのコマンドラインツール。
+- [OpenAI Codex CLI](https://github.com/openai/codex) - ターミナルで動作するOpenAIの軽量コーディングエージェント
+
+## AIコーディングタスク管理
+
+- [Boomerang Tasks](https://docs.roocode.com/features/boomerang-tasks) - 複雑なプロジェクトを自動的に小さく管理可能な部分に分解。
+- [Claude Task Master](https://github.com/eyaltoledano/claude-task-master) - Cursor、Lovable、Windsurf、Rooなどに組み込めるAI駆動タスク管理システム。
+
+## AIコーディングドキュメント
+
+- [CodeGuide](https://www.codeguide.dev/) - AIコーディングプロジェクト用の詳細ドキュメントを作成。
+
+## ニュースとソーシャルメディア
+
+> このセクションは時系列逆順で項目を表示し、最新のエントリが上部に表示されます。
+
+- [Peer Programming with LLMs, For Senior+ Engineers](https://pmbanugo.me/blog/peer-programming-with-llms)
+- 🔥 [The Way of Code | Rick Rubin](https://www.thewayofcode.com/)
+- [The State of Vibe Coding Tools (May 2025) | LinkedIn](https://www.linkedin.com/pulse/state-vibe-coding-tools-may-2025-nufar-gaspar-x1znf/?trackingId=iJSsdxE4R9OECPT43FtBww%3D%3D)
+- [Vibe coding MenuGen | karpathy](https://karpathy.bearblog.dev/vibe-coding-menugen/)
+- [Two publishers and three authors fail to understand what "vibe coding" means](https://simonwillison.net/2025/May/1/not-vibe-coding/)
+- [Not all AI-assisted programming is vibe coding (but vibe coding rocks)](https://simonwillison.net/2025/Mar/19/vibe-coding/)
+- [Vibe Coding 101 with Replit - DeepLearning.AI](https://www.deeplearning.ai/short-courses/vibe-coding-101-with-replit/)
+- [The "vibe coding" mind virus explained… by Fireship - YouTube](https://www.youtube.com/watch?v=Tw18-4U7mts)
+- [Not all AI-assisted programming is vibe coding (but vibe coding rocks)](https://simonwillison.net/2025/Mar/19/vibe-coding/)
+- [bolt.new on X - "Introducing Figma to Bolt Go from Figma to pixel-perfect full stack app - X](https://x.com/boltdotnew/status/1900197121829331158)
+- [Will the future of software development run on vibes? - Ars Technica](https://arstechnica.com/ai/2025/03/is-vibe-coding-with-ai-gnarly-or-reckless-maybe-some-of-both/)
+- [Vibe Coding - Where Everyone Can 'Speak' Computer Programming - The New Stack](https://thenewstack.io/vibe-coding-where-everyone-can-speak-computer-programming/)
+- [A.I. and Vibecoding Helped Me to Create My Own Software - The New York Times](https://www.nytimes.com/2025/02/27/technology/personaltech/vibecoding-ai-software-programming.html)
+- [/r/vibecoding](https://www.reddit.com/r/vibecoding/)
+- [/r/ChatGPTCoding](https://www.reddit.com/r/ChatGPTCoding/)
+
+## 貢献
+
+貢献を歓迎します！まず[貢献ガイドライン](CONTRIBUTING.md)をお読みください。

--- a/README-KR.md
+++ b/README-KR.md
@@ -2,7 +2,7 @@
 
 > AI와 협업하여 코드를 작성하는 '바이브 코딩' 참고자료 모음집입니다.
 
-[English](./README.md) | 한국어
+[English](./README.md) | 한국어 | [中文](./README-CN.md) | [日本語](./README-JP.md)
 
 ## 목차
 - [컨셉 소개](#컨셉-소개)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A curated list of vibe coding references, collaborating with AI to write code.
 
-English | [한국어](./README-KR.md)
+English | [한국어](./README-KR.md) | [中文](./README-CN.md) | [日本語](./README-JP.md)
 
 ## Contents <!-- omit in toc -->
 


### PR DESCRIPTION
## Summary
Added Chinese and Japanese translations for the README to help more developers access this resource.

## What's Changed
Added README-CN.md (Chinese version)
Added README-JP.md (Japanese version)
Updated navigation links in existing README files

## Details

Translated all sections while keeping the original structure
All links and formatting preserved
Navigation works between all language versions (EN/KR/CN/JP)
Hopefully this makes the awesome vibe coding list useful for more people! 🚀