### PR TITLE
Add blank-space to Browser-based Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - 🔥 [Bolt.new](https://bolt.new/) - Prompt, run, edit, and deploy full-stack web and mobile apps.
 - 🔥 [Lovable](https://lovable.dev/) - "Idea to app in seconds. Lovable is your superhuman full stack engineer".
 - 🔥 [v0 by Vercel](https://v0.dev/chat) - Assistant to build NextJS frontend.
+- 🔥 [blank-space](https://www.blankspace.build/) - Open-source AI app builder. Alternative to v0, Lovable, and Bolt.
 - [Capacity](https://capacity.so/) - "Capacity lets you turn your ideas into fully functional web apps in minutes using AI.".
 - [CHAI.new by Langbase](https://chai.new) - Prompt to vibe code any AI agent and deploy (agent, app, api)
 - [Replit](https://replit.com/) - "Simply describe your idea above and let the Agent build it for you".


### PR DESCRIPTION
## Summary

Adding [blank-space](https://www.blankspace.build/) to the **Browser-based Tools** section.

## Details

- **Repository**: https://github.com/BrandeisPatrick/blank-space
- **Website**: https://www.blankspace.build/
- **Description**: An open-source AI app builder alternative to v0, Lovable, and Bolt
- **Category**: Browser-based vibe coding tool

blank-space is a perfect fit for this list as it enables vibe coding - building full-stack applications through AI-assisted development, similar to the other browser-based tools listed.