### PR TITLE
Add Blank Space to Browser-based Tools

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -41,6 +41,7 @@
 - [Firebase Studio](https://studio.firebase.google.com/) - Google的代理云开发环境，帮助构建和发布生产级全栈AI应用。
 - [Napkins.dev](https://www.napkins.dev/) - 截图转代码
 - [HeroUI Chat](https://heroui.chat/) - 无论你的设计经验如何，都能生成美丽的应用。
+- [Blank Space](https://www.blankspace.build/) - 开源AI应用构建器。v0、Lovable和Bolt的替代品。
 
 ## IDE和代码编辑器
 

--- a/README-JP.md
+++ b/README-JP.md
@@ -41,6 +41,7 @@
 - [Firebase Studio](https://studio.firebase.google.com/) - 本格的なフルスタックAIアプリの構築と出荷を支援するGoogleのエージェンティッククラウド開発環境。
 - [Napkins.dev](https://www.napkins.dev/) - スクリーンショットからコードへ
 - [HeroUI Chat](https://heroui.chat/) - デザイン経験に関係なく美しいアプリを生成。
+- [Blank Space](https://www.blankspace.build/) - オープンソースAIアプリビルダー。v0、Lovable、Boltの代替。
 
 ## IDEとコードエディタ
 

--- a/README-KR.md
+++ b/README-KR.md
@@ -36,6 +36,7 @@
 - [Firebase Studio](https://studio.firebase.google.com/) - Google이 만든 AI 기반 풀스택 앱 제작 환경.
 - [Napkins.dev](https://www.napkins.dev/) - 스크린샷을 코드로 변환합니다.
 - [HeroUI Chat](https://heroui.chat/) - 디자인 경험에 관계없이 아름다운 앱을 만들어 보세요.
+- [Blank Space](https://www.blankspace.build/) - 오픈소스 AI 앱 빌더. v0, Lovable, Bolt의 대안.
 
 ## IDE 및 코드 에디터
 - [Windsurf Editor by Codeium](https://codeium.com/windsurf) - 개발자와 AI가 진정으로 함께하는 마법 같은 코딩 경험을 제공하는 IDE.

--- a/README-PT.md
+++ b/README-PT.md
@@ -41,6 +41,7 @@
 - [Firebase Studio](https://studio.firebase.google.com/) - Ambiente de desenvolvimento baseado na nuvem do Google que ajuda a construir e implantar aplicações de IA full-stack de qualidade de produção.
 - [Napkins.dev](https://www.napkins.dev/) - Do screenshot para código
 - [HeroUI Chat](https://heroui.chat/) - Gere aplicações bonitas independentemente da sua experiência em design.
+- [Blank Space](https://www.blankspace.build/) - Construtor de aplicações de IA open-source. Alternativa ao v0, Lovable e Bolt.
 
 ## IDEs e Editores de Código
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [HeroUI Chat](https://heroui.chat/) - Generate beautiful apps regardless of your design experience.
 - [Rocket.new](https://www.rocket.new/) - "Build Web & Mobile Apps 10x Faster Without Code".
 - [Google AI Studio](https://aistudio.google.com/) - "Another way to vibecode with Gemini. Great for experimenting".
+- [Blank Space](https://www.blankspace.build/) - Open-source AI app builder. Alternative to v0, Lovable, and Bolt.
 
 ## IDEs and Code Editors
 


### PR DESCRIPTION
Adding [Blank Space](https://www.blankspace.build/) to the Browser-based Tools section.

**Why it's awesome:**
- Open-source (Apache-2.0)
- Self-hostable alternative to v0, Lovable, and Bolt
- Build web apps using natural language

**Source:** https://github.com/BrandeisPatrick/blank-space

Updated all 5 language versions:
- README.md (English)
- README-PT.md (Portuguese)
- README-KR.md (Korean)
- README-CN.md (Chinese)
- README-JP.md (Japanese)