### PR TITLE
Add memov to command line tools

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -80,6 +80,7 @@
 ## 命令行工具
 
 - 🔥 [anthropics/claude-code](https://github.com/anthropics/claude-code) - 理解你的代码库、自动化任务、解释代码和管理git的编程代理，全部通过自然语言。
+- [memovai/memov](https://github.com/memovai/memov) - 基于 Git 的 Claude Coding 可回溯记忆层。
 - [aider](https://aider.chat/) - 在终端中进行AI结对编程。
 - [codename goose](https://block.github.io/goose/) - 本地机器AI代理，允许你使用任何LLM并添加任何MCP服务器作为扩展
 - [MyCoder.ai](https://github.com/drivecore/mycoder) - 开源AI驱动的编程助手，具有Git和GitHub集成，支持并行执行和自修改功能。

--- a/README-JP.md
+++ b/README-JP.md
@@ -80,6 +80,7 @@
 ## コマンドラインツール
 
 - 🔥 [anthropics/claude-code](https://github.com/anthropics/claude-code) - コードベースを理解し、タスクを自動化し、コードを説明し、gitを管理するコーディングエージェント、すべて自然言語で。
+- [memovai/memov](https://github.com/memovai/memov) - Git ベースの Claude Coding 用トレース可能なメモリレイヤー。
 - [aider](https://aider.chat/) - ターミナルでのAIペアプログラミング。
 - [codename goose](https://block.github.io/goose/) - 任意のLLMを使用し、任意のMCPサーバーを拡張として追加できるローカルマシンAIエージェント
 - [MyCoder.ai](https://github.com/drivecore/mycoder) - GitとGitHub統合、並列実行と自己修正機能を備えたオープンソースAI駆動コーディングアシスタント。

--- a/README-KR.md
+++ b/README-KR.md
@@ -80,6 +80,7 @@
 ## 명령행 도구
 
 - 🔥 [anthropics/claude-code](https://github.com/anthropics/claude-code) - 자연어를 통해 코드베이스 이해, 작업 자동화, 코드 설명 및 git 관리 가능.
+- [memovai/memov](https://github.com/memovai/memov) - Git 기반 Claude Coding 추적 가능한 메모리 레이어.
 - [aider](https://aider.chat/) - 터미널에서 AI 페어 프로그래밍 지원.
 - [codename goose](https://block.github.io/goose/) - 로컬 AI 에이전트로, 다양한 LLM과 MCP 서버 확장 지원.
 - [MyCoder.ai](https://github.com/drivecore/mycoder) - Git 및 GitHub 통합, 병렬 실행 및 자기 수정 기능을 갖춘 오픈소스 AI 기반 코딩 어시스턴트.

--- a/README-PT.md
+++ b/README-PT.md
@@ -80,6 +80,7 @@
 ## Ferramentas de Linha de Comando
 
 - 🔥 [anthropics/claude-code](https://github.com/anthropics/claude-code) - Agente de codificação que entende sua base de código, automatiza tarefas, explica código e gerencia git, tudo via linguagem natural.
+- [memovai/memov](https://github.com/memovai/memov) - Camada de memória rastreável baseada em Git para Claude Coding.
 - [aider](https://aider.chat/) - Faça um pair programming com a IA no seu terminal.
 - [codename goose](https://block.github.io/goose/) - Agente de IA local, na máquina, que permite usar qualquer LLM e adicionar qualquer servidor MCP como extensões.
 - [MyCoder.ai](https://github.com/drivecore/mycoder) - Assistente de codificação com IA de código aberto com integração Git e GitHub, apresentando capacidades de execução paralela e auto-modificação.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 ## Command Line Tools
 
 - 🔥 [anthropics/claude-code](https://github.com/anthropics/claude-code) - Coding agent that understands your codebase, automates tasks, explains code, and manages git, all via natural language.
+- [memovai/memov](https://github.com/memovai/memov) - Git-based, traceable memory layer for Claude Code.
 - [aider](https://aider.chat/) - AI pair programming in your terminal.
 - [codename goose](https://block.github.io/goose/) - Local, on-machine AI Agent that allows you to use any LLM and add any MCP servers as extensions
 - [MyCoder.ai](https://github.com/drivecore/mycoder) - Open source AI-powered coding assistant with Git and GitHub integration, featuring parallel execution and self-modification capabilities.


### PR DESCRIPTION
## Summary
- add `memovai/memov` to CLI/tooling lists
- highlight its Git-based, traceable memory layer for Claude Coding
- keep ordering and style consistent with existing entries

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist
- [x] Links are valid and point to the official repository
- [x] Follows existing list style and section placement
- [x] No code changes or tests required