### PR TITLE
Add vnsh - Ephemeral encrypted file sharing for AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [opencode](https://opencode.ai/) - "AI coding agent built for the terminal".
 - [charmbracelet/crush](https://github.com/charmbracelet/crush) - "The glamorous AI coding agent for your favourite terminal", generates command line interfaces.
 - [Warp](https://www.warp.dev/) - A Rust-based command line featuring native AI integration.
+- [vnsh](https://github.com/raullenchai/vnsh) - Ephemeral encrypted file sharing for AI. Pipe logs, diffs, and files into secure URLs that Claude can read directly. Auto-vaporizes in 24h.
 - [vibe-cli](https://github.com/Jinjos/vibe-cli) - An AI-powered CLI tool that enables collaborative coding sessions, code generation, and workflow automation directly from your terminal.
 - [langchain-code](https://github.com/zamalali/langchain-code) - LangChain-based coding agent for AI-assisted development.
 - [kimi-cli](https://github.com/MoonshotAI/kimi-cli) - Official command-line interface for Kimi, an AI assistant that helps with coding tasks and development workflows.


### PR DESCRIPTION
## New Tool: vnsh

**vnsh** - The Ephemeral Dropbox for AI

### Category
Command Line Tools

### What it does
vnsh solves the "Context Injection" problem in AI coding workflows. When your logs, diffs, or debug context is too long to paste directly:

```bash
# Pipe anything to vnsh
git diff HEAD~5 | vn
docker logs app | vn
cat crash.log | vn

# Get a secure link that Claude can read directly
# https://vnsh.dev/v/abc123#k=...
```

### Key Features
- **Zero-Access Architecture**: Client-side AES-256 encryption - server never sees your data
- **Auto-Vaporization**: Data auto-destructs after 24 hours
- **MCP Integration**: Claude Code can read vnsh links natively via `vnsh-mcp`
- **Cross-Platform**: CLI works on macOS, Windows, Linux

### Links
- **Repository**: https://github.com/raullenchai/vnsh
- **npm CLI**: https://www.npmjs.com/package/vnsh-cli
- **npm MCP**: https://www.npmjs.com/package/vnsh-mcp
- **Website**: https://vnsh.dev