### PR TITLE
Add MyVibe - Instant publishing for vibe coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Gentleman-Programming/gentleman-guardian-angel](https://github.com/Gentleman-Programming/gentleman-guardian-angel) - Provider-agnostic code review using AI. Use Claude, Gemini, Codex, Ollama to enforce your coding standards.
 - [superagent-ai/grok-cli](https://github.com/superagent-ai/grok-cli) - Command-line interface for AI-powered coding assistance.
 - [GitHub Copilot CLI](https://github.com/github/copilot-cli) - GitHub Copilot coding agent directly in your terminal with agentic capabilities, GitHub integration, and MCP-powered extensibility.
+- [MyVibe](https://www.myvibe.so) - Claude Code skill for instant publishing. Type `/myvibe:publish` to deploy AI-generated projects to live URLs in seconds. The publish command vibe coding was missing.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
## Add MyVibe

Adding MyVibe to the Command Line Tools section.

### What is MyVibe?

MyVibe is a Claude Code skill that provides instant publishing for vibe-coded projects. It's the publish command vibe coding was missing.

### The Problem

Vibe coding makes building fast, but deployment still takes hours. MyVibe fixes this:

```bash
/myvibe:publish → live URL in seconds
```

### Features

- **One command deployment** - No DevOps required
- **Auto-detection** - Detects HTML, Vite, React, Next.js projects
- **Instant sharing** - Get a live URL immediately

### Links

- Website: https://www.myvibe.so
- Skills Repository: https://github.com/ArcBlock/myvibe-skills