### PR TITLE
Add nom

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -115,6 +115,7 @@
 - [AGENTS.md](https://agents.md/) - 一种简单、开放的编程代理指导格式。
 - [KhazP/vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template) - 氛围编程的提示词模板。
 - [awesome-ralph](https://github.com/snwfdhmp/awesome-ralph) - 关于Ralph的精选资源列表，Ralph是一种氛围编程技术，可以在自动循环中运行氛围编程代理，直到满足规格要求。
+- [nom](https://github.com/nom-social/nom) - 实时聚合你的GitHub项目活动的社交动态，附带AI生成摘要，帮助团队追踪和分享议题、拉取请求及发布版本的更新。
 
 ## 社区和招聘平台
 

--- a/README-JP.md
+++ b/README-JP.md
@@ -115,6 +115,7 @@
 - [AGENTS.md](https://agents.md/) - コーディングエージェントをガイドするためのシンプルでオープンなフォーマット。
 - [KhazP/vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template) - バイブコーディング用のプロンプトテンプレート。
 - [awesome-ralph](https://github.com/snwfdhmp/awesome-ralph) - 仕様が満たされるまで自動ループでバイブコーディングエージェントを実行するRalphというバイブコーディング技術に関するリソースの厳選リスト。
+- [nom](https://github.com/nom-social/nom) - AI要約付きでGitHubプロジェクトのアクティビティをリアルタイムに集約するソーシャルフィード。イシュー、プルリクエスト、リリースの更新をチームで追跡・共有できます。
 
 ## コミュニティと求人掲示板
 

--- a/README-KR.md
+++ b/README-KR.md
@@ -115,6 +115,7 @@
 - [AGENTS.md](https://agents.md/) - 코딩 에이전트를 안내하기 위한 간단하고 개방적인 형식.
 - [KhazP/vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template) - 바이브 코딩을 위한 프롬프트 템플릿.
 - [awesome-ralph](https://github.com/snwfdhmp/awesome-ralph) - 명세가 충족될 때까지 자동화된 루프에서 바이브 코딩 에이전트를 실행하는 기법인 Ralph에 대한 리소스 모음집.
+- [nom](https://github.com/nom-social/nom) - AI 요약 기능을 갖춘 GitHub 프로젝트 활동의 실시간 소셜 피드. 이슈, PR, 릴리즈 업데이트를 팀이 함께 추적하고 공유할 수 있습니다.
 
 ## 커뮤니티 및 구인 게시판
 

--- a/README-PT.md
+++ b/README-PT.md
@@ -115,6 +115,7 @@
 - [AGENTS.md](https://agents.md/) - Um formato simples e aberto para orientar agentes de codificação.
 - [KhazP/vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template) - Um template de prompt para vibe coding.
 - [awesome-ralph](https://github.com/snwfdhmp/awesome-ralph) - Uma lista selecionada de recursos sobre Ralph, a técnica de vibe coding que executa agentes de vibe coding em loops automatizados até que as especificações sejam cumpridas.
+- [nom](https://github.com/nom-social/nom) - Um feed social em tempo real das atividades do seu projeto GitHub com resumos gerados por IA, ajudando equipes a rastrear e compartilhar atualizações de issues, pull requests e releases.
 
 ## Comunidades e Vagas de Emprego
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [AGENTS.md](https://agents.md/) - A simple, open format for guiding coding agents.
 - [KhazP/vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template) - A prompt template for vibe coding.
 - [awesome-ralph](https://github.com/snwfdhmp/awesome-ralph) - A curated list of resources about Ralph, the vibe coding technique that runs vibe coding agents in automated loops until specifications are fulfilled.
+- [nom](https://github.com/nom-social/nom) - A real-time social feed of your GitHub project activities with AI-powered summaries, helping teams track and share repository updates across issues, pull requests, and releases.
 
 ## Communities & Job Boards
 


### PR DESCRIPTION
## Summary

Adds [nom](https://github.com/nom-social/nom) to the **Documentation for AI Coding** section.

nom is a real-time social feed that aggregates GitHub project activities with AI-powered summaries, helping teams track and share repository updates across issues, pull requests, and releases. It's a useful tool for staying on top of AI coding projects without manually checking multiple repositories.

## Changes

- Added nom to `Documentation for AI Coding` in `README.md` (English) and all localized READMEs (CN, JP, KR, PT).