### PR TITLE
Add cursor-lint to Command Line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 
 ## Command Line Tools
 
+- [cursor-lint](https://github.com/cursorrulespacks/cursor-lint) - Linter for Cursor AI rule files (.mdc and .cursorrules). Catches broken frontmatter, missing fields, and other issues that silently break AI code generation. Also available as a [GitHub Action](https://github.com/cursorrulespacks/cursor-lint-action).
 - 🔥 [anthropics/claude-code](https://github.com/anthropics/claude-code) - Coding agent that understands your codebase, automates tasks, explains code, and manages Git, all via natural language.
 - [aider](https://aider.chat/) - AI pair programming in your terminal.
 - [codename goose](https://block.github.io/goose/) - Local, on-machine AI Agent that allows you to use any LLM and add any MCP servers as extensions.


### PR DESCRIPTION
Adds [cursor-lint](https://github.com/cursorrulespacks/cursor-lint) — a linter for Cursor AI rule files (.mdc and .cursorrules).

It catches broken YAML frontmatter, missing `alwaysApply` fields, empty rule bodies, and other issues that silently break AI code generation. Zero dependencies.

```bash
npx cursor-lint
npx cursor-lint --fix
```

Also available as a [GitHub Action](https://github.com/cursorrulespacks/cursor-lint-action) for CI and a [VS Code extension](https://open-vsx.org/extension/nedcodes/cursor-lint).