### PR TITLE
Add Claude Code Open to Command Line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 ## Command Line Tools
 
 - 🔥 [anthropics/claude-code](https://github.com/anthropics/claude-code) - Coding agent that understands your codebase, automates tasks, explains code, and manages Git, all via natural language.
+- [Claude Code Open](https://github.com/kill136/claude-code-open) - Open-source AI coding platform with Web IDE, multi-agent system, 37+ tools, and MCP protocol support. Based on Claude Code with added browser-based IDE, Blueprint multi-agent orchestration, and scheduled task daemon.
 - [aider](https://aider.chat/) - AI pair programming in your terminal.
 - [codename goose](https://block.github.io/goose/) - Local, on-machine AI Agent that allows you to use any LLM and add any MCP servers as extensions.
 - [MyCoder.ai](https://github.com/drivecore/mycoder) - Open source AI-powered coding assistant with Git and GitHub integration, featuring parallel execution and self-modification capabilities.


### PR DESCRIPTION
## Add Claude Code Open

Adding [Claude Code Open](https://github.com/kill136/claude-code-open) to the Command Line Tools section.

**Claude Code Open** is an open-source AI coding platform (MIT licensed) that extends Claude Code with:

- **Web IDE** — Full browser-based IDE with Monaco editor, file tree, and AI-enhanced editing
- **Blueprint Multi-Agent System** — Smart Planner + Lead Agent + Autonomous Workers for complex task orchestration
- **37+ Built-in Tools** — File ops, search, execution, web access, browser automation, scheduled tasks, and more
- **MCP Protocol** — Full Model Context Protocol support with auto-discovery (stdio, HTTP, SSE)
- **One-Click Install** — Automated scripts for Windows/macOS/Linux
- **Self-Evolution** — AI can modify its own source code with safety checks and hot-reload

GitHub: https://github.com/kill136/claude-code-open (100+ stars)
License: MIT