### PR TITLE
Add Zero Engineer — real-world vibe coding case study from Japan

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 
 > This section displays items in reverse chronological order, with the most recent entries at the top.
 
+- [Zero Engineer](https://github.com/sstklen/zero-engineer) - How an animal sanctuary owner in Japan with zero coding background built a production API platform (30+ APIs, 50K LOC) using Claude Code, Codex CLI, and Gemini CLI as a 3-agent team. Includes real incident reports, lessons learned, and 112 extracted skills.
 - [The Prompt Engineering Playbook for Programmers](https://addyo.substack.com/p/the-prompt-engineering-playbook-for)
 - [What is vibe coding? A computer scientist explains what it means to have AI write computer code − and what risks that can entail](https://theconversation.com/what-is-vibe-coding-a-computer-scientist-explains-what-it-means-to-have-ai-write-computer-code-and-what-risks-that-can-entail-257172)
 - [Peer Programming with LLMs, For Senior+ Engineers](https://pmbanugo.me/blog/peer-programming-with-llms)


### PR DESCRIPTION
## What

Adding [Zero Engineer](https://github.com/sstklen/zero-engineer) as a real-world vibe coding case study.

## Why it fits

- Author had zero engineering background, built a production API platform using only AI agents
- 7 months, 30+ API integrations, 50K lines of code, $550/month total cost
- Documents the honest truth: what AI is good at, what it's bad at, and what "the real skill" actually is
- Includes real 3am outage stories, security incidents, and billing bugs
- All resources open-sourced including 112 reusable Claude Code skills