### PR TITLE
Add OpenPaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Gentleman-Programming/gentleman-guardian-angel](https://github.com/Gentleman-Programming/gentleman-guardian-angel) - Provider-agnostic code review using AI. Use Claude, Gemini, Codex, Ollama to enforce your coding standards.
 - [superagent-ai/grok-cli](https://github.com/superagent-ai/grok-cli) - Command-line interface for AI-powered coding assistance.
 - [GitHub Copilot CLI](https://github.com/github/copilot-cli) - GitHub Copilot coding agent directly in your terminal with agentic capabilities, GitHub integration, and MCP-powered extensibility.
+- [OpenPaw](https://github.com/daxaur/openpaw) - Open-source CLI that turns Claude Code into a personal assistant with 38 skills including email, calendar, Spotify, smart home, Slack, and more.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
**OpenPaw** ([GitHub](https://github.com/daxaur/openpaw)) is an open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills — email, calendar, Spotify, smart home, Slack, GitHub, and more.

Users describe what they want in natural language and Claude handles it, making it a natural fit for the vibe coding ecosystem. MIT licensed.

I'm the maintainer of OpenPaw and would love to see it included in this list.