### PR TITLE
Add cursor-rules collection to Documentation for AI Coding section

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [CodeGuide](https://www.codeguide.dev/) - Creates detailed Documentation for your AI Coding Projects.
 - [AGENTS.md](https://agents.md/) - A simple, open format for guiding coding agents.
 - [KhazP/vibe-coding-prompt-template](https://github.com/KhazP/vibe-coding-prompt-template) - A prompt template for vibe coding.
+- [survivorforge/cursor-rules](https://github.com/survivorforge/cursor-rules) - 35+ production-quality .cursorrules files for 16 frameworks (React, Next.js, Python, Go, Rust, SvelteKit, Django, and more). Ready-to-use AI coding conventions for Cursor and Claude Code. MIT licensed.
 - [awesome-ralph](https://github.com/snwfdhmp/awesome-ralph) - A curated list of resources about Ralph, the vibe coding technique that runs vibe coding agents in automated loops until specifications are fulfilled.
 
 ## Communities & Job Boards


### PR DESCRIPTION
## What is this?

Adds [survivorforge/cursor-rules](https://github.com/survivorforge/cursor-rules) to the **Documentation for AI Coding** section.

## Why does it belong here?

This is a curated collection of 35+ production-quality `.cursorrules` files for 16 popular frameworks including React, Next.js, Python, Go, Rust, SvelteKit, and Django. These files are documentation artifacts that configure AI coding assistants — specifically Cursor and Claude Code — with framework-specific conventions for code style, architecture, and testing.

This fits the "Documentation for AI Coding" section perfectly: it is a resource that helps developers document their coding standards in a format that AI tools can understand and follow during vibe coding sessions.

## Checklist
- [x] Entry is in the correct section (Documentation for AI Coding)
- [x] Description is concise and explains the value
- [x] Link points to an active, maintained GitHub repository
- [x] MIT licensed
- [x] Follows existing format in the list