### PR TITLE
Add dna-claude-analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 
 > This section displays items in reverse chronological order, with the most recent entries at the top.
 
+- [shmlkv/dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) - Personal genome analysis toolkit built entirely with Claude Code. Analyzes raw DNA data (23andMe, AncestryDNA) across 17 categories and generates a terminal-style HTML dashboard.
 - [The Prompt Engineering Playbook for Programmers](https://addyo.substack.com/p/the-prompt-engineering-playbook-for)
 - [What is vibe coding? A computer scientist explains what it means to have AI write computer code − and what risks that can entail](https://theconversation.com/what-is-vibe-coding-a-computer-scientist-explains-what-it-means-to-have-ai-write-computer-code-and-what-risks-that-can-entail-257172)
 - [Peer Programming with LLMs, For Senior+ Engineers](https://pmbanugo.me/blog/peer-programming-with-llms)


### PR DESCRIPTION
Adding [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) to the News and Social Media section.

A personal genome analysis toolkit I built entirely through vibe coding with Claude Code. It takes raw DNA data from services like 23andMe or AncestryDNA and analyzes it across 17 categories (ancestry, health risks, nutrition, pharmacogenomics, etc.), then generates a single-page terminal-style HTML dashboard with the results.

The whole project — Python analysis scripts, report generation, and the final webpage — was built through conversation without manually writing code.