### PR TITLE
Add Autohand Code CLI to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 
 - 🔥 [anthropics/claude-code](https://github.com/anthropics/claude-code) - Coding agent that understands your codebase, automates tasks, explains code, and manages Git, all via natural language.
 - [aider](https://aider.chat/) - AI pair programming in your terminal.
+- [Autohand Code CLI](https://github.com/autohandai/code-cli) - Self-evolving autonomous coding agent for the terminal with 40+ tools, multi-LLM support (OpenRouter, Anthropic, OpenAI, Ollama), and a modular skills system.
 - [codename goose](https://block.github.io/goose/) - Local, on-machine AI Agent that allows you to use any LLM and add any MCP servers as extensions.
 - [MyCoder.ai](https://github.com/drivecore/mycoder) - Open source AI-powered coding assistant with Git and GitHub integration, featuring parallel execution and self-modification capabilities.
 - [ai-christianson/RA.Aid](https://github.com/ai-christianson/RA.Aid) - A standalone coding agent built on LangGraph's agent-based task execution framework.


### PR DESCRIPTION
Hi! 👋

I'd like to add **[Autohand Code CLI](https://github.com/autohandai/code-cli)** to this awesome list under the Command Line Tools section.

Autohand Code CLI is a self-evolving autonomous coding agent that runs in your terminal. Built with autonomy and scalability at its core, it uses the ReAct pattern to reason about and modify entire codebases through natural language.

**Key highlights:**
- 40+ built-in autonomous tools (file ops, git, search, multi-file editing)
- Multiple LLM providers (OpenRouter, Anthropic, OpenAI, Ollama, local models)
- Modular skill system and semantic code search
- VS Code and Zed editor extensions
- Session management with resume capability
- Apache 2.0 licensed

Website: https://www.autohand.ai/code/

Thanks for maintaining this great resource!