### PR TITLE
Add OpenPaw to Command Line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Gentleman-Programming/gentleman-guardian-angel](https://github.com/Gentleman-Programming/gentleman-guardian-angel) - Provider-agnostic code review using AI. Use Claude, Gemini, Codex, Ollama to enforce your coding standards.
 - [superagent-ai/grok-cli](https://github.com/superagent-ai/grok-cli) - Command-line interface for AI-powered coding assistance.
 - [GitHub Copilot CLI](https://github.com/github/copilot-cli) - GitHub Copilot coding agent directly in your terminal with agentic capabilities, GitHub integration, and MCP-powered extensibility.
+- [daxaur/openpaw](https://github.com/daxaur/openpaw) - Open-source personal assistant wizard for Claude Code with 39+ skills including focus mode, task dashboard, scheduling, and more.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
[OpenPaw](https://github.com/daxaur/openpaw) is an open-source personal assistant wizard for Claude Code. It adds 39+ installable skills — focus mode with distraction blocking, task dashboard, scheduling, messaging, browser automation, and more — via a single `npx pawmode` setup command.

- Open-source, no daemon, no extra cost
- Ships as an npm package (`npx pawmode`)
- Each skill is a standalone SKILL.md — no lock-in