### PR TITLE
Add BurnRate

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Gentleman-Programming/gentleman-guardian-angel](https://github.com/Gentleman-Programming/gentleman-guardian-angel) - Provider-agnostic code review using AI. Use Claude, Gemini, Codex, Ollama to enforce your coding standards.
 - [superagent-ai/grok-cli](https://github.com/superagent-ai/grok-cli) - Command-line interface for AI-powered coding assistance.
 - [GitHub Copilot CLI](https://github.com/github/copilot-cli) - GitHub Copilot coding agent directly in your terminal with agentic capabilities, GitHub integration, and MCP-powered extensibility.
+- [BurnRate](https://github.com/burnrate-dev/burnrate) - Track AI coding tool usage and costs across Claude Code, Cursor, Copilot, Windsurf, Aider, Cline, and Codex with optimization recommendations.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
## What is BurnRate?

[BurnRate](https://getburnrate.io) is a local-first CLI tool that tracks AI coding tool usage and costs across 7 providers: Claude Code, Cursor, GitHub Copilot, Windsurf, Aider, Cline, and OpenAI Codex.

Added to the **Command Line Tools** section as it helps vibe coders monitor and optimize their AI tool spending.

**Key features:**
- Real-time cost analytics dashboard
- 46 optimization rules to reduce spending
- Rate limit monitoring
- Team budgets and alerts
- PDF report generation
- Written in Go, single binary, no dependencies

GitHub: https://github.com/burnrate-dev/burnrate