### PR TITLE
Add onWatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Gentleman-Programming/gentleman-guardian-angel](https://github.com/Gentleman-Programming/gentleman-guardian-angel) - Provider-agnostic code review using AI. Use Claude, Gemini, Codex, Ollama to enforce your coding standards.
 - [superagent-ai/grok-cli](https://github.com/superagent-ai/grok-cli) - Command-line interface for AI-powered coding assistance.
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
+- [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
## Add onWatch

[onWatch](https://github.com/onllm-dev/onwatch) is an open-source Go CLI that tracks AI API quota usage across 7 providers — Anthropic, OpenAI, GitHub Copilot, MiniMax, and more. It runs as a background daemon with <50MB RAM and zero telemetry, helping vibe coders keep track of their API limits while using tools like Claude Code, Codex CLI, Cursor, Cline, Roo Code, and others.

**Why it's awesome:**
- Solves a real pain point for vibe coders who burn through API quotas across multiple providers
- Lightweight Go binary (~15MB), runs in the background without getting in the way
- Material Design 3 web dashboard for at-a-glance quota visibility
- Works with all major vibe coding tools listed in this repo
- GPL-3.0 licensed, 342+ stars