### PR TITLE
Add ORCH to Task Management for AI Coding section

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 
 - [Boomerang Tasks](https://docs.roocode.com/features/boomerang-tasks) - Automatically break down complex projects into smaller, manageable pieces.
 - [Claude Task Master](https://github.com/eyaltoledano/claude-task-master) - An AI-powered task-management system you can drop into Cursor, Lovable, Windsurf, Roo, and others.
+- [ORCH](https://github.com/oxgeneral/ORCH) - CLI orchestrator that manages Claude Code, Codex, Cursor as a typed AI team with state machine, auto-retry, TUI dashboard, and inter-agent messaging.
 - 🔥 [vibe-kanban](https://github.com/BloopAI/vibe-kanban) - A kanban board to manage and orchestrate AI coding agents. Supports 10+ coding agents.
 - [CCPM (Claude Code PM)](https://github.com/automazeio/ccpm) - Project management for Claude Code using GitHub Issues and Git worktrees for parallel agent execution.
 - [Archon](https://github.com/coleam00/Archon) - Knowledge and task management backbone for AI coding assistants via MCP.


### PR DESCRIPTION
## What

Adds [ORCH](https://github.com/oxgeneral/ORCH) to the **Task Management for AI Coding** section.

## Entry

```
- [ORCH](https://github.com/oxgeneral/ORCH) - CLI orchestrator that manages Claude Code, Codex, Cursor as a typed AI team with state machine, auto-retry, TUI dashboard, and inter-agent messaging.
```

## Why it belongs here

ORCH is an open-source CLI/npm runtime for orchestrating teams of AI coding agents. It fits the Task Management section because:

- **Formal state machine**: tasks flow `todo → in_progress → review → done` with mandatory review gate before completion
- **Auto-retry resilience**: failed agent runs automatically enter `retrying` state — no manual restart needed
- **Inter-agent messaging**: agents communicate via `orch msg send/broadcast` — unique among CLI orchestrators
- **Goal → Task hierarchy**: high-level goals decompose into tracked tasks across your agent team
- **Multi-adapter**: manages Claude Code, OpenAI Codex, Cursor, OpenCode, and shell agents from one CLI
- **Programmatic API**: `@oxgeneral/orch` exports full engine API for embedding in Node.js apps
- **TypeScript strict + 1493 tests** — production-ready

## Checklist

- [x] Entry follows the list format (link + description)
- [x] Placed alphabetically (O comes after C entries, before V)
- [x] GitHub repo is public and active
- [x] Description is concise and factual