### PR TITLE
Add llm.log to Command Line Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Gentleman-Programming/gentleman-guardian-angel](https://github.com/Gentleman-Programming/gentleman-guardian-angel) - Provider-agnostic code review using AI. Use Claude, Gemini, Codex, Ollama to enforce your coding standards.
 - [superagent-ai/grok-cli](https://github.com/superagent-ai/grok-cli) - Command-line interface for AI-powered coding assistance.
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
-- [llm.log](https://github.com/lanesket/llm.log) - See exactly what Claude Code, Codex, Cursor and other agents are sending to LLM APIs — token usage, costs, full prompts and responses, latency. Local proxy, zero code changes, single binary.
+- [llm.log](https://github.com/lanesket/llm.log) - See exactly what Claude Code and other AI agents are sending to LLM APIs — token usage, costs, full prompts and responses, latency. Local proxy, zero code changes, single binary.
 
 ## Task Management for AI Coding
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Gentleman-Programming/gentleman-guardian-angel](https://github.com/Gentleman-Programming/gentleman-guardian-angel) - Provider-agnostic code review using AI. Use Claude, Gemini, Codex, Ollama to enforce your coding standards.
 - [superagent-ai/grok-cli](https://github.com/superagent-ai/grok-cli) - Command-line interface for AI-powered coding assistance.
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
-- [llm.log](https://github.com/lanesket/llm.log) - Local MITM proxy with TUI dashboard for monitoring LLM API calls — token usage, real costs, latency and full request inspector. Supports OpenAI, Anthropic and OpenRouter. Zero code changes, single binary, pure Go.
+- [llm.log](https://github.com/lanesket/llm.log) - See exactly what Claude Code, Codex, Cursor and other agents are sending to LLM APIs — token usage, costs, full prompts and responses, latency. Local proxy, zero code changes, single binary.
 
 ## Task Management for AI Coding
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Gentleman-Programming/gentleman-guardian-angel](https://github.com/Gentleman-Programming/gentleman-guardian-angel) - Provider-agnostic code review using AI. Use Claude, Gemini, Codex, Ollama to enforce your coding standards.
 - [superagent-ai/grok-cli](https://github.com/superagent-ai/grok-cli) - Command-line interface for AI-powered coding assistance.
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
+- [llm.log](https://github.com/lanesket/llm.log) - Local MITM proxy with TUI dashboard for monitoring LLM API calls — token usage, real costs, latency and full request inspector. Supports OpenAI, Anthropic and OpenRouter. Zero code changes, single binary, pure Go.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
Adds [llm.log](https://github.com/lanesket/llm.log) to the Command Line Tools section.

llm.log is a local MITM proxy with TUI dashboard for monitoring LLM API calls — token usage, real costs, latency and full request inspector. Works via `HTTPS_PROXY` with zero code changes, so it captures traffic from any vibe coding tool automatically. Single binary, pure Go, MIT licensed.