### PR TITLE
Add claude-scaffold — npx CLI for deploying Claude Code workflow across repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Gentleman-Programming/gentleman-guardian-angel](https://github.com/Gentleman-Programming/gentleman-guardian-angel) - Provider-agnostic code review using AI. Use Claude, Gemini, Codex, Ollama to enforce your coding standards.
 - [superagent-ai/grok-cli](https://github.com/superagent-ai/grok-cli) - Command-line interface for AI-powered coding assistance.
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
+- [claude-scaffold](https://github.com/pyramidheadshark/claude-scaffold) - npx CLI that deploys your full Claude Code setup (CLAUDE.md, hooks, skills) to any repo in one command, with auto-activating domain skills and cross-repo sync.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
Adding claude-scaffold to the Command Line Tools section.

It solves a common vibe coding friction point: every new repo requires recreating the same CLAUDE.md + hooks setup. `npx claude-scaffold init` deploys the full configuration in one command, with 18 domain skills that auto-activate based on what's in the project.

Cross-repo sync: `npx claude-scaffold update --all` keeps every registered repo on the same version.

- GitHub: https://github.com/pyramidheadshark/claude-scaffold
- npm: https://npmjs.com/package/claude-scaffold