### PR TITLE
Add launch-swarm to Task Management for AI Coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [CCPM (Claude Code PM)](https://github.com/automazeio/ccpm) - Project management for Claude Code using GitHub Issues and Git worktrees for parallel agent execution.
 - [Archon](https://github.com/coleam00/Archon) - Knowledge and task management backbone for AI coding assistants via MCP.
 - [AI-DLC Workflows (AWS Labs)](https://github.com/awslabs/aidlc-workflows) - AI-Driven Development Life Cycle workflow rules for coding agents. Supports Kiro, Q Developer, Cursor, Cline, Claude Code.
+- [launch-swarm](https://github.com/harshmoney123/launch-swarm) - 6-agent Claude Code swarm with strict role separation, dual-gate merge pipeline, and prompt health. Agents plan, code, review, document, and deploy autonomously.
 
 ## Documentation for AI Coding
 


### PR DESCRIPTION
launch-swarm is a .claude configuration that turns vibe coding into vibe engineering. 6 specialized AI agents with strict role boundaries, dual-gate merge pipeline, and self-healing prompt instructions. Used daily in production at a YC W23 startup.