### PR TITLE
Add IM.codes - The IM for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 ## Mobile Apps
 
 - [VibeCode](https://www.vibecodeapp.com/) - The app that builds apps. Available on iOS and Android.
+- [IM.codes](https://github.com/im4codes/imcodes) - Mobile/web control layer for Claude Code, Codex, Gemini CLI, and other terminal-based coding agents, built for away-from-desk continuation from phone or browser.
 
 ## Plugins and Extensions
 


### PR DESCRIPTION
Add IM.codes under **Mobile Apps**.

IM.codes is a mobile/web control layer for Claude Code, Codex, Gemini CLI, and other terminal-based coding agents. The main differentiator is away-from-desk continuation: it keeps long-running agent workflows within reach from phone or browser instead of limiting them to the desktop.

Repo: https://github.com/im4codes/imcodes