### PR TITLE
Add Vibeyard to Local Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - 🔥 [Dyad](https://www.dyad.sh/) - Free, local, open-source AI app builder. Model-agnostic, supports cloud models and local via Ollama.
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
+- [Vibeyard](https://github.com/elirantutia/vibeyard) - Open-source Electron desktop app that wraps Claude Code in a multi-session IDE with split panes, swarm mode, cost tracking, session resume, P2P sharing, and AI readiness scoring.
 
 ## Command Line Tools
 


### PR DESCRIPTION
## What is Vibeyard
Terminal-centric IDE for AI coding agents, starting with Claude Code.

## Why it fits "Local Apps"
- Desktop Electron app (macOS, installable via npm or .dmg)
- Similar to Superset and bolt.diy already listed
- Multi-session management, swarm mode, real-time cost tracking, P2P session sharing
- Open source (MIT)

GitHub: https://github.com/elirantutia/vibeyard