### PR TITLE
Add Onepilot to Mobile Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 ## Mobile Apps
 
 - [VibeCode](https://www.vibecodeapp.com/) - The app that builds apps. Available on iOS and Android.
+- [Onepilot](https://onepilotapp.com/) - SSH into remote servers and run AI coding agents (Claude Code, Codex) from your iPhone. Vibe code on mobile.
 
 ## Plugins and Extensions
 


### PR DESCRIPTION
Adds [Onepilot](https://onepilotapp.com/) to the **Mobile Apps** section. Onepilot is an iOS app that lets you SSH into remote servers and run AI coding agents (Claude Code, Codex, etc.) directly from your phone -- bringing vibe coding to mobile. Describe what you want, and the agent writes the code on your server while you watch from anywhere. Follows the existing entry format.