### PR TITLE
Add LIIVO to Browser-based Tools - deploy apps your AI built

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Emergent](https://emergent.sh/) - Multi-agent AI app builder that plans, codes, tests, and deploys full-stack web and mobile apps autonomously.
 - [Manus](https://manus.im/) - Autonomous AI agent for end-to-end project automation, from research to deployment.
 - [Same.new](https://same.new/) - AI web builder for cloning and creating websites from descriptions.
+- [LIIVO](https://www.liivo.ai) - Deploy apps your AI built. Connect Claude or ChatGPT, describe what you want, and LIIVO runs it on open-source infrastructure you can take anywhere. Flat EUR 15/month, zero vendor lock-in.
 
 ## IDEs and Code Editors
 


### PR DESCRIPTION
## What is LIIVO?

[LIIVO](https://www.liivo.ai) fills the gap after vibe coding: once your AI has built the app, LIIVO runs it. Connect Claude or ChatGPT, describe what you want, and LIIVO deploys it on open-source infrastructure you can take anywhere. Flat EUR 15/month, zero vendor lock-in.

## Why it fits here

Vibe coding tools help you generate apps from prompts. LIIVO is the deployment layer for non-technical users who want to go from "AI wrote this" to "it is actually running." It runs on fully open-source infrastructure, so there is no lock-in - you can move to any cloud or self-host at any time.

Added to the `Browser-based Tools` section alphabetically after Same.new.

## Entry added

```
- [LIIVO](https://www.liivo.ai) - Deploy apps your AI built. Connect Claude or ChatGPT, describe what you want, and LIIVO runs it on open-source infrastructure you can take anywhere. Flat EUR 15/month, zero vendor lock-in.
```