### PR TITLE
Add codebase-recon to Command Line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [superagent-ai/grok-cli](https://github.com/superagent-ai/grok-cli) - Command-line interface for AI-powered coding assistance.
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [codebase-recon](https://github.com/yujiachen-y/codebase-recon-skill) - AI agent skill that analyzes git history to reveal codebase hotspots, bug magnets, bus factor risks, and development momentum before reading any code. Works with 20+ coding agents.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
Adds [codebase-recon](https://github.com/yujiachen-y/codebase-recon-skill) to the **Command Line Tools** section.

An AI coding agent skill that analyzes git history to understand a codebase before reading any code. It reveals:

- **Code hotspots** — most frequently changed files
- **Bug magnets** — files associated with fix/bug commits
- **High-risk files** — cross-referenced hotspots × bug magnets
- **Bus factor** — contributor knowledge concentration
- **Team momentum** — rising / stable / declining trend
- **Firefighting frequency** — reverts, hotfixes, emergency commits

Install via [skills.sh](https://skills.sh): `npx skills add yujiachen-y/codebase-recon-skill`

Works with 20+ coding agents (Claude Code, Cursor, Cline, GitHub Copilot, Gemini CLI, etc.) via the [Agent Skills Specification](https://agentskills.io/specification).