### PR TITLE
Add teleping and Coolreadme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [GitHub Copilot CLI](https://github.com/github/copilot-cli) - Full agentic development environment in the terminal with Autopilot mode, multi-model support, and GitHub integration. GA since Feb 2026.
 - [MyCoder.ai](https://github.com/drivecore/mycoder) - Open source AI-powered coding assistant with Git and GitHub integration, featuring parallel execution and self-modification capabilities.
 - [ai-christianson/RA.Aid](https://github.com/ai-christianson/RA.Aid) - A standalone coding agent built on LangGraph's agent-based task execution framework.
+- [teleping](https://github.com/yerdaulet-damir/teleping) - Production observability for solo builders: structured Telegram alerts with batching, quiet hours, progress bars, tables, and checklists — 1 import, zero deps.
 - [CodeSelect](https://github.com/maynetee/codeselect) - A Python-based command-line tool that efficiently communicates project source code to AIs.
 - [QwenLM/qwen-code](https://github.com/QwenLM/qwen-code) - "qwen-code is a coding agent that lives in digital world".
 - [charmbracelet/crush](https://github.com/charmbracelet/crush) - "The glamorous AI coding agent for your favourite terminal", multi-model with beautiful TUI.
@@ -144,6 +145,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [claude-reflect](https://github.com/BayramAnnakov/claude-reflect) - Self-learning system for Claude Code that captures corrections and syncs approved learnings to CLAUDE.md files.
 - [EnzeD/vibe-coding](https://github.com/EnzeD/vibe-coding) - The Ultimate Guide to Vibe Coding with best practices and tips.
 - [Claude Code Organizer](https://github.com/mcpware/claude-code-organizer) - Visual dashboard and MCP server to organize Claude Code memories, skills, MCP servers, and hooks with scope hierarchy and drag-and-drop.
+- [Coolreadme](https://coolreadme.xyz) - Generate GitHub profile and project READMEs with AI-powered templates and live customization preview.
 
 ## Communities & Job Boards
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [claude-reflect](https://github.com/BayramAnnakov/claude-reflect) - Self-learning system for Claude Code that captures corrections and syncs approved learnings to CLAUDE.md files.
 - [EnzeD/vibe-coding](https://github.com/EnzeD/vibe-coding) - The Ultimate Guide to Vibe Coding with best practices and tips.
 - [Claude Code Organizer](https://github.com/mcpware/claude-code-organizer) - Visual dashboard and MCP server to organize Claude Code memories, skills, MCP servers, and hooks with scope hierarchy and drag-and-drop.
-- [Coolreadme](https://coolreadme.xyz) - Generate GitHub profile and project READMEs with AI-powered templates and live customization preview.
+- [Coolreadme](https://coolreadme.xyz) - 29+ embeddable GitHub profile cards — Netflix, YouTube, Steam, Twitch, X/Twitter, Now Listening, animated streak pet cards, and AI identity badges. Paste a URL into your README and it just works.
 
 ## Communities & Job Boards
 


### PR DESCRIPTION
## What

Adds two tools built for the vibe coding workflow:

1. **[teleping](https://github.com/yerdaulet-damir/teleping)** → Command Line Tools section
2. **[Coolreadme](https://coolreadme.xyz)** → Documentation for AI Coding section

## Why they fit

**teleping** — Production observability designed for solo builders in the Cursor/Vercel/Supabase stack. Sends structured Telegram alerts (errors, signups, metrics) with batching, quiet hours, progress bars, tables, and checklists. 1 import, zero deps. Built specifically for the vibe coding loop.

**Coolreadme** — AI-powered README generator with live preview. Helps vibe coders ship polished GitHub profiles and project docs without leaving the flow.

## Checklist

- [x] Added to correct sections
- [x] Entries placed at bottom of respective sections (per CONTRIBUTING.md)
- [x] Format: `- [Name](url) - Description ending with period.`
- [x] No duplicates
- [x] Commit message: `Add teleping and Coolreadme`