### PR TITLE
Add vibe-replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [vibe-replay](https://github.com/tuo-lei/vibe-replay) - Turn AI coding sessions into shareable, interactive HTML replays with animated playback, insights, and PR integration. Supports Claude Code and Cursor.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
Adds [vibe-replay](https://github.com/tuo-lei/vibe-replay) to the **Command Line Tools** section.

vibe-replay turns AI coding sessions (Claude Code, Cursor) into shareable, interactive HTML replays with animated playback, insights, and PR integration.