### PR TITLE
Add SuperLocalMemory to Documentation for AI Coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [claude-reflect](https://github.com/BayramAnnakov/claude-reflect) - Self-learning system for Claude Code that captures corrections and syncs approved learnings to CLAUDE.md files.
 - [EnzeD/vibe-coding](https://github.com/EnzeD/vibe-coding) - The Ultimate Guide to Vibe Coding with best practices and tips.
 - [Claude Code Organizer](https://github.com/mcpware/claude-code-organizer) - Visual dashboard and MCP server to organize Claude Code memories, skills, MCP servers, and hooks with scope hierarchy and drag-and-drop.
+- [SuperLocalMemory](https://github.com/qualixar/superlocalmemory) - Persistent memory for AI coding tools (Claude Code, Cursor, Copilot). Remembers context and patterns across sessions. Zero-cloud, local-first. MCP server + CLI.
 
 ## Communities & Job Boards
 


### PR DESCRIPTION
## Add SuperLocalMemory

Adds [SuperLocalMemory](https://github.com/qualixar/superlocalmemory) to the **Documentation for AI Coding** section.

**What it does:** Gives AI coding tools (Claude Code, Cursor, Copilot) persistent memory across sessions — context, preferences, and patterns survive restarts. Zero-cloud, local-first. Available as MCP server + CLI.

- **npm:** 5,000+ downloads/month
- **Research:** 3 peer-reviewed papers on arXiv
- **License:** AGPL-3.0
- **GitHub:** 98+ stars

Closes #97