### PR TITLE
Add SoxAI - AI API gateway for vibe coding tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [superagent-ai/grok-cli](https://github.com/superagent-ai/grok-cli) - Command-line interface for AI-powered coding assistance.
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
+- [SoxAI](https://www.soxai.io) - AI API gateway that works with Claude Code, Codex CLI, Gemini CLI, and OpenCode. One API key for 200+ models, automatic failover, team spending limits. Set `ANTHROPIC_BASE_URL` to use with any vibe coding tool. ([Setup Guide](https://github.com/onedotnet/soxai-examples/tree/main/cli))
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
 
 ## Task Management for AI Coding


### PR DESCRIPTION
Added SoxAI to the Command Line Tools section, alongside onWatch (API quota tracking).

[SoxAI](https://www.soxai.io) is an AI API gateway that works with vibe coding tools like Claude Code, Codex CLI, Gemini CLI, and OpenCode. Developers set `ANTHROPIC_BASE_URL` or `OPENAI_BASE_URL` to use SoxAI as their API backend, getting:

- **200+ models** through one API key (use Claude, GPT, Gemini, DeepSeek in any CLI tool)
- **Automatic failover** — if Anthropic is down, requests route to another provider
- **Team spending limits** — prevent runaway costs from vibe coding sessions
- **Unified billing** across all coding tools and providers

Setup guides for each CLI tool: https://github.com/onedotnet/soxai-examples/tree/main/cli