### PR TITLE
Add AI Dev Jobs to Communities & Job Boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [/r/ChatGPTCoding](https://www.reddit.com/r/ChatGPTCoding/)
 - [Vibe Coding Forem](https://vibe.forem.com/) - Community forum for AI-assisted development discussions.
 - [Vibe Coding Community](https://github.com/Vibe-Coding-Community) - A space for sharing tools, best practices, and projects created with vibe coding.
+- [AI Dev Jobs](https://aidevboard.com) - AI/ML-focused job board with 7,700+ positions from 440+ companies, REST API, and MCP server for AI-powered job search.
 
 ## News and Social Media
 


### PR DESCRIPTION
Adds [AI Dev Jobs](https://aidevboard.com) to the Communities & Job Boards section.

AI Dev Jobs is an AI/ML-focused job board featuring 7,700+ positions from 440+ companies. It includes a REST API and MCP server, making it particularly relevant for vibe coding workflows where developers can search for AI engineering roles programmatically.

- Website: https://aidevboard.com
- API docs: https://aidevboard.com/api-pricing
- MCP server: https://aidevboard.com/mcp