### PR TITLE
Add AgentsMesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [CCPM (Claude Code PM)](https://github.com/automazeio/ccpm) - Project management for Claude Code using GitHub Issues and Git worktrees for parallel agent execution.
 - [Archon](https://github.com/coleam00/Archon) - Knowledge and task management backbone for AI coding assistants via MCP.
 - [AI-DLC Workflows (AWS Labs)](https://github.com/awslabs/aidlc-workflows) - AI-Driven Development Life Cycle workflow rules for coding agents. Supports Kiro, Q Developer, Cursor, Cline, Claude Code.
+- [AgentsMesh](https://github.com/AgentsMesh/AgentsMesh) - Kanban board that orchestrates Claude Code, Codex CLI, Gemini CLI, Aider, and OpenCode in parallel git worktrees. Self-hostable with per-pod MCP server.
 
 ## Documentation for AI Coding
 


### PR DESCRIPTION
Adds AgentsMesh to Task Management for AI Coding.

Same space as vibe-kanban — Kanban + orchestrator for parallel AI coding agents across git worktrees. Runs Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode. Open source at https://github.com/AgentsMesh/AgentsMesh.

Appended to the bottom of the category per CONTRIBUTING.