### PR TITLE
Add Codex Infinity to Command Line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [Codex Infinity](https://codex-infinity.com) - Autonomous coding agent on bare metal VPS. Runs continuously with full root access, supporting Claude Max and OpenAI Codex CLI plans with no cloud timeouts.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
## Summary
- Adds [Codex Infinity](https://codex-infinity.com) to the Command Line Tools section
- Codex Infinity is an autonomous coding agent that runs continuously on bare metal VPS with full root access, supporting Claude Max and OpenAI Codex CLI plans with no cloud timeouts

## Test plan
- [ ] Verify list formatting renders correctly
- [ ] Confirm link resolves to https://codex-infinity.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)