### PR TITLE
Add vibecodex — production architecture bible for vibe-coders

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [claude-reflect](https://github.com/BayramAnnakov/claude-reflect) - Self-learning system for Claude Code that captures corrections and syncs approved learnings to CLAUDE.md files.
 - [EnzeD/vibe-coding](https://github.com/EnzeD/vibe-coding) - The Ultimate Guide to Vibe Coding with best practices and tips.
 - [Claude Code Organizer](https://github.com/mcpware/claude-code-organizer) - Visual dashboard and MCP server to organize Claude Code memories, skills, MCP servers, and hooks with scope hierarchy and drag-and-drop.
+- [vibecodex](https://github.com/yerdaulet-damir/vibecodex) - Production architecture bible for vibe-coders: 54 principles for FastAPI, Next.js 15 & Go 1.22+, with CLAUDE.md templates, Claude Code skills, and cursor rules.
 
 ## Communities & Job Boards
 


### PR DESCRIPTION
## vibecodex

🔗 https://github.com/yerdaulet-damir/vibecodex

### The problem
Vibe-coders ship fast but accumulate invisible architectural debt — code that works in a Claude session but breaks in production. No shared vocabulary for "production-ready" when AI writes the code.

### What vibecodex is
A production architecture bible specifically designed for AI-assisted development:

- **54 numbered principles** (A1–F10) for FastAPI, Next.js 15, Go 1.22+ — covering hexagonal architecture, ACL patterns, bulkhead isolation, single-writer, idempotency, and more
- **CLAUDE.md template** — copy into any project so Claude loads architecture rules at session start  
- **8 Claude Code skills** — systematic debugging, new feature preflight, add-provider checklist, monolith splitting
- **`.cursor/rules`** for all 3 stacks
- **Reference app** with working tests (11 passing)
- **Architecture lint script** — catches violations statically with grep

### Why it fits this list
vibecodex is the missing foundation layer for serious vibe-coding — it's what prevents the "works locally, breaks in prod" pattern that plagues AI-generated code.