### PR TITLE
Add AgentPlane to Task Management for AI Coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [CCPM (Claude Code PM)](https://github.com/automazeio/ccpm) - Project management for Claude Code using GitHub Issues and Git worktrees for parallel agent execution.
 - [Archon](https://github.com/coleam00/Archon) - Knowledge and task management backbone for AI coding assistants via MCP.
 - [AI-DLC Workflows (AWS Labs)](https://github.com/awslabs/aidlc-workflows) - AI-Driven Development Life Cycle workflow rules for coding agents. Supports Kiro, Q Developer, Cursor, Cline, Claude Code.
+- [AgentPlane](https://github.com/basilisk-labs/agentplane) - Git-native task-lifecycle control for vibe-coded repositories, recording plans, verification, and closure evidence in Git.
 
 ## Documentation for AI Coding
 


### PR DESCRIPTION
Hi - I would like to add AgentPlane to this list.

Disclosure: I maintain AgentPlane.

Why it fits:
AgentPlane is not another coding agent. It is a Git-native task-lifecycle control layer for repo-local coding-agent work, with accepted plans, verification notes, finish records, and closure evidence written inside the repository.

Category:
`Task Management for AI Coding`. This is the closest existing category because AgentPlane helps make vibe-coded repository work auditable and resumable through explicit task, plan, verify, and finish state.

Entry added:
AgentPlane - Git-native task-lifecycle control for vibe-coded repositories, recording plans, verification, and closure evidence in Git.

Verification:
- `git diff --check`
- Confirmed the entry is present in `README.md`
- `npx --yes awesome-lint` ran, but the full command exits non-zero on pre-existing issues unrelated to this entry: duplicate Warp links and an existing lowercase `git` spelling warning.

Happy to adjust category, wording, or remove if this is outside scope.
