### PR TITLE
Add agenttrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [agenttrace](https://github.com/luoyuctl/agenttrace) - Local-first TUI observability for AI coding-agent sessions across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor, Qwen Code, Cline, OpenCode/OpenClaw, Kimi CLI, and JSON/JSONL traces.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
Adds agenttrace to Command Line Tools.

Resource: https://github.com/luoyuctl/agenttrace

Why it is awesome: agenttrace helps vibe coding users inspect local AI coding agent sessions across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, and more.

Validation:
- git diff --check passed
- npx awesome-lint currently reports existing duplicate Warp links in the upstream README.