### PR TITLE
Add SwarmClaw to Command Line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [SwarmClaw](https://github.com/swarmclawai/swarmclaw) - Self-hosted runtime that orchestrates Claude Code, Codex, Gemini CLI, OpenCode, Copilot CLI, Cursor Agent, Goose, Qwen Code, and Droid behind a unified org chart with delegation, schedules, runtime skills, and persistent memory. Multi-provider, MCP-native. CLI, Electron desktop app, and Docker.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
Adds [SwarmClaw](https://github.com/swarmclawai/swarmclaw) under Command Line Tools.

SwarmClaw is a self-hosted runtime that orchestrates Claude Code, Codex, Gemini CLI, OpenCode, Copilot CLI, Cursor Agent, Goose, Qwen Code, and Droid behind a unified org chart view with delegation, schedules, runtime skills, persistent memory, and reviewed conversation-to-skill learning. It is multi-provider (Anthropic, OpenAI, Google, Ollama, DeepSeek, Groq, Together, Mistral, xAI, Fireworks, and 13+ others) and MCP-native (server and client).

Ships as a CLI, Electron desktop app, and Docker image. MIT, TypeScript.

- Repo: https://github.com/swarmclawai/swarmclaw
- License: MIT