### PR TITLE
Add ToutKit to Local Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
+- [ToutKit](https://github.com/toutkit/toutkit) - Local-first desktop notebook for AI CLIs (Claude Code, Codex, Gemini): each note is a self-contained folder with its own SQLite, files, and scripts, and the AI writes interactive HTML pages rendered inline instead of plain text. Built with Electron, AGPL-3.0.
 
 ## Command Line Tools
 


### PR DESCRIPTION
Adds [**ToutKit**](https://github.com/toutkit/toutkit) to **Local Apps**.

ToutKit is a local-first desktop notebook for AI coding CLIs. It pairs a sidebar of notes with a built-in terminal for Claude Code / Codex / Gemini and an in-app webview that renders whatever the AI writes — so answers come back as interactive HTML pages instead of walls of text. Each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool without leaving your filesystem.

Why it's awesome for vibe coding: most vibe-coded outputs end up as throwaway snippets in a chat window. ToutKit gives them a permanent home — every prompt becomes a runnable, editable, shareable mini-app, organized in a folder you actually own.

- Repo: https://github.com/toutkit/toutkit
- License: AGPL-3.0
- Stack: Electron / JavaScript
- Cross-platform: macOS, Windows, Linux