### PR TITLE
Add VULK (vulk.dev) to Browser-based Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Emergent](https://emergent.sh/) - Multi-agent AI app builder that plans, codes, tests, and deploys full-stack web and mobile apps autonomously.
 - [Manus](https://manus.im/) - Autonomous AI agent for end-to-end project automation, from research to deployment.
 - [Same.new](https://same.new/) - AI web builder for cloning and creating websites from descriptions.
+- [VULK](https://vulk.dev/) - Full-stack AI app builder generating React + PostgreSQL apps, real Flutter mobile builds, Three.js/WebGL games and Shopify themes from prompts. BYOM with 16+ models, Firecracker microVM live preview, EU-hosted, full code export.
 
 ## IDEs and Code Editors
 


### PR DESCRIPTION
Adds [VULK](https://vulk.dev/) to the **Browser-based Tools** section, alongside Bolt.new, Lovable, v0, Capacity, Replit, Emergent, etc.

VULK turns natural-language prompts into deployable full-stack apps. It differentiates from existing entries on:

- **Real Flutter mobile builds** — server-side .apk/.ipa with code-signing (not React Native wrapper)
- **Three.js / WebGL / shaders** — generates browser games and immersive WebGL sites
- **Shopify Liquid themes** — full Online Store 2.0 theme generation
- **BYOM** — bring-your-own-LLM-key (OpenAI / Anthropic / Google / Mistral / Groq / OpenRouter / Ollama) with zero markup
- **Firecracker microVM live preview** — same isolation tech as AWS Lambda, <2s cold-boot
- **EU-hosted** — Postgres on AWS Frankfurt, app on Hetzner; full source code export (ZIP + GitHub push)
- **Public REST API + OpenAPI 3.1** at https://vulk.dev/openapi.json so AI agents can call VULK as a tool
- **MCP server** `vulk-mcp-server` on npm for Claude Desktop / Cursor / Windsurf

Built solo by João Castro (Portugal). Live at https://vulk.dev.