### PR TITLE
Add great_cto to Command Line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [great_cto](https://github.com/avelikiy/great_cto) - Engineering management layer for 34 specialist AI agents covering the full SDLC (architect, pm, senior-dev, code-reviewer, qa, security, devops + 18 archetype-specific reviewers). 25 archetypes auto-detected with compliance gates (PCI-DSS, HIPAA, GDPR). Runs in Claude Code, Cursor, Codex CLI, Aider, Continue. Local kanban board, OWASP LLM Top 10 scanner, MIT.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
Adding [great_cto](https://github.com/avelikiy/great_cto) to **Command Line Tools**.

34-agent SDLC orchestrator that runs in Claude Code, Cursor, Codex CLI, Aider, Continue (one config, all 5 platforms). Auto-detects 25 archetypes from package.json/pyproject.toml/Cargo.toml and attaches compliance gates (PCI-DSS, HIPAA, GDPR, EU AI Act, COPPA). Local kanban board (no SaaS), OWASP LLM Top 10 scanner built-in, MIT licensed.

Inserted at end of CLI tools section (newest entries appear last in this list).