### PR TITLE
Add prpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
 
+- [prpack](https://github.com/Lucas2944/prpack) - Zero-dependency Node CLI that packs a pull request (diff plus the full post-change content of every touched file) into a single markdown file optimized for LLM code review.
+
 ## Task Management for AI Coding
 
 - [Boomerang Tasks](https://docs.roocode.com/features/boomerang-tasks) - Automatically break down complex projects into smaller, manageable pieces.


### PR DESCRIPTION
[prpack](https://github.com/Lucas2944/prpack) is a zero-dependency Node CLI (MIT) that packs a pull request — diff plus the full post-change content of every touched file — into a single markdown file optimized for LLM code review.

Why it fits this list: it's a CLI tool for the vibe-coding workflow of reviewing PRs with an LLM. Drop the output into Claude / Cursor / your model and get a review that has the surrounding context, not just the diff.

Per the contributing guide: entry placed at the bottom of Command Line Tools, single link, short description, ends with punctuation.