### PR TITLE
Add OpenQuack

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
+- [OpenQuack](https://github.com/larryxiao/openquack) - Privacy-first local voice dictation menu bar app for macOS. Pairs with Claude Code, Cursor, Codex, and Aider to dictate long contextual prompts; WhisperKit on Apple Silicon, ~8 MB, MIT.
 
 ## Command Line Tools
 


### PR DESCRIPTION
Adds OpenQuack to **Local Apps**.

OpenQuack is a privacy-first, MIT-licensed local voice dictation menu-bar app for macOS. The vibe-coding angle: it pairs with AI coding agents (Claude Code, Cursor, Codex, Aider) — press a hotkey, dictate the long contextual prompt that would be slow to type, and the transcript pastes at the cursor in any prompt bar. Transcription is on-device via WhisperKit on Apple Silicon, ~8 MB binary.

Repo: https://github.com/larryxiao/openquack

Per CONTRIBUTING — single-line bullet, hyphen separator, appended at bottom of Local Apps section.

Thanks for maintaining the list.