### PR TITLE
Add ArcadeLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [/r/ChatGPTCoding](https://www.reddit.com/r/ChatGPTCoding/)
 - [Vibe Coding Forem](https://vibe.forem.com/) - Community forum for AI-assisted development discussions.
 - [Vibe Coding Community](https://github.com/Vibe-Coding-Community) - A space for sharing tools, best practices, and projects created with vibe coding.
+- [ArcadeLab](https://arcadelab.ai/) - Free no-signup hosting for single-file HTML games, visualizations, and interactive content vibe-coded with AI. Paste a complete HTML file, get a permanent shareable URL.
 
 ## News and Social Media
 


### PR DESCRIPTION
Hi! Adding ArcadeLab to the Communities & Job Boards section.

**[ArcadeLab](https://arcadelab.ai/)** is a free no-signup hosting platform for single-file HTML content vibe-coded with AI — games, visualizations, simulations, and explorables. Creators (typically working with Claude, ChatGPT, Cursor, etc.) paste a complete HTML file at arcadelab.ai/publish and get a permanent shareable URL. No account, no email, no build tools.

Why it fits the list:
- It solves the "I just vibe-coded this thing — now what?" problem that comes up after most vibe coding sessions
- It's specifically designed around the single-HTML-file output that AI assistants produce naturally
- It's free and open source ([github.com/mlapeter/arcadelab](https://github.com/mlapeter/arcadelab))

Added alphabetically-ish at the bottom of the Communities & Job Boards section, alongside Vibehackers (which is the closest existing entry — community gallery for vibe-coded projects).

Followed the format and style of existing entries. One PR for the one suggestion per CONTRIBUTING. Thanks for maintaining the list!