### PR TITLE
feat: add Mneme HQ to Command Line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
 
+- [Mneme HQ](https://github.com/TheoV823/mneme) - Architectural governance layer for AI-assisted development. Injects project decisions into LLM workflows and blocks architectural violations before generation. Works with Claude Code, Cursor, and agent frameworks.
 ## Task Management for AI Coding
 
 - [Boomerang Tasks](https://docs.roocode.com/features/boomerang-tasks) - Automatically break down complex projects into smaller, manageable pieces.


### PR DESCRIPTION
**[Mneme HQ](https://github.com/TheoV823/mneme)** — architectural governance layer for AI-assisted development.

Added to **Command Line Tools**, after `pyscn`.

Mneme HQ runs before the LLM call: it retrieves relevant architectural decisions from `project_memory.json` and injects them as a structured system prompt. The `mneme check` CLI then scans generated output for constraint and anti-pattern violations. Works with Claude Code, Cursor, Cline, and agent frameworks. No vector store, no ML dependencies, pip-installable.

- **License**: MIT
- **Language**: Python 3.11+