### PR TITLE
Add Intent Specification Layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [EnzeD/vibe-coding](https://github.com/EnzeD/vibe-coding) - The Ultimate Guide to Vibe Coding with best practices and tips.
 - [Claude Code Organizer](https://github.com/mcpware/claude-code-organizer) - Visual dashboard and MCP server to organize Claude Code memories, skills, MCP servers, and hooks with scope hierarchy and drag-and-drop.
 - 🔥 [getdesign.md](https://getdesign.md/) - Browsable library of DESIGN.md files curated from real websites.
+- [Intent Specification Layer](https://github.com/philo-kim/intent-spec-layer) - Spec layer for AI coding agents that turns intent into EARS requirements and verification obligations.
 
 ## Communities & Job Boards
 


### PR DESCRIPTION
Adds Intent Specification Layer to Documentation for AI Coding.

It is a repository-native spec layer for AI coding agents that turns product intent into EARS requirements, statement IDs, and verification obligations so generated stubs are not mistaken for real tests.

Resource: https://github.com/philo-kim/intent-spec-layer