### PR TITLE
Add Agent FM

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 
 - 🔥 [Dyad](https://www.dyad.sh/) - Free, local, open-source AI app builder. Model-agnostic, supports cloud models and local via Ollama.
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
+- [Agent FM](https://github.com/agentfm-ai/agent-fm) - Local, open-source macOS app for listening to Claude Code and Codex agents as they work, with Global Mix, blocker alerts, and BYOK narration.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
 


### PR DESCRIPTION
Adds Agent FM to Local Apps.

Agent FM is a local, open-source macOS app for listening to Claude Code and Codex agents as they work. It fits this list as a vibe-coding workflow tool for following parallel coding-agent sessions with live narration, Global Mix, and blocker alerts.
