### PR TITLE
Add codex-profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [codex-profiles](https://github.com/Ducksss/codex-profiles) - Bash CLI wrapper for switching OpenAI Codex CLI/Desktop accounts with isolated `CODEX_HOME` profiles, keeping auth, config, sessions, connectors, plugins, and logs separated without copying token files.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
## Summary

Adds codex-profiles to Command Line Tools. It is a Bash wrapper around Codex's CODEX_HOME support for switching Codex CLI/Desktop accounts while keeping auth, config, sessions, connectors, plugins, and logs separated.

## Validation

- Ran `git diff --check`.