### PR TITLE
Add Everything OpenAI Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [aichat](https://github.com/sigoden/aichat) - All-in-one LLM CLI tool featuring shell assistant, REPL mode, RAG, AI tools and agents, supporting 20+ providers.
 - [gptme](https://github.com/ErikBjare/gptme) - A personal AI agent in your terminal, equipped with local tools for coding, shell commands, file editing, and web browsing.
 - [OpenAI Codex CLI](https://github.com/openai/codex) - OpenAI's coding agent in the terminal with Codex Cloud, IDE extension, and multi-model support.
+- [Everything OpenAI Codex](https://github.com/mturac/everything-openai-codex) - Open-source Codex workflow system with agents, skills, commands, hooks, memory patterns, install profiles, and validation checks.
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli) - An open-source AI agent from Google that brings the power of Gemini directly into your terminal. Generous free tier (60 req/min, 1000/day).
 - [GitHub Copilot CLI](https://github.com/github/copilot-cli) - Full agentic development environment in the terminal with Autopilot mode, multi-model support, and GitHub integration. GA since Feb 2026.
 - [MyCoder.ai](https://github.com/drivecore/mycoder) - Open source AI-powered coding assistant with Git and GitHub integration, featuring parallel execution and self-modification capabilities.


### PR DESCRIPTION
Adds Everything OpenAI Codex to the Command Line Tools section.\n\nIt is an open-source Codex workflow system with agents, skills, commands, hooks, memory patterns, install profiles, and validation checks.

Everything OpenAI Codex is an MIT-licensed Codex workflow system, not a prompt dump: it packages a repeatable Intake -> Route -> Plan -> Execute -> Verify -> Capture -> Resume loop with agents, skills, hooks, install profiles, memory/status capture, validation checks, and cross-harness adapters.

Project: https://github.com/mturac/everything-openai-codex
README execution model: https://github.com/mturac/everything-openai-codex#eoc-execution-model