### PR TITLE
Add vibeprompt to Documentation for AI Coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [llms.txt](https://github.com/AnswerDotAI/llms-txt) - Standardized markdown file specification for making website documentation LLM-friendly.
 - [claude-reflect](https://github.com/BayramAnnakov/claude-reflect) - Self-learning system for Claude Code that captures corrections and syncs approved learnings to CLAUDE.md files.
 - [EnzeD/vibe-coding](https://github.com/EnzeD/vibe-coding) - The Ultimate Guide to Vibe Coding with best practices and tips.
+- [vibeprompt](https://vibeprompt.tech) - Free 10-step vibe coding workflow with 56 prompts, 17 deep-dive articles, 46 field-tested fixes, and an interactive AGENTS.md + PRD generator. Open source, MIT licensed.
 - [Claude Code Organizer](https://github.com/mcpware/claude-code-organizer) - Visual dashboard and MCP server to organize Claude Code memories, skills, MCP servers, and hooks with scope hierarchy and drag-and-drop.
 - 🔥 [getdesign.md](https://getdesign.md/) - Browsable library of DESIGN.md files curated from real websites.
 


### PR DESCRIPTION
Adds [vibeprompt](https://vibeprompt.tech) to the Documentation for AI Coding section.

**What it is:** a free, open-source, web-based resource for vibe coders. Bundles:
- 10-step interactive workflow (with localStorage-saved checklists) from idea to shipped
- 56 battle-tested prompts grouped by workflow stage
- 17 long-form articles with real receipts from shipped apps
- 46 field-tested fixes for problems indie devs hit (security, conversion, burnout, etc.)
- Interactive AGENTS.md + PRD generator — fill in fields, get ready-to-use markdown

**Why it fits this section:** vibeprompt's core artifact is the methodology + docs that guide AI coding agents (AGENTS.md templates, PRD format, memory-bank structure). It pairs well with the existing AGENTS.md, KhazP template, EnzeD guide, and llms.txt entries.

MIT licensed, no sign-up, runs in the browser. Source: github.com/dotsystemsdevs/vibe-prompt.

Thanks for maintaining this list! 🙏