### PR TITLE
Add Primio

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [HeyBoss](https://heyboss.ai/) - "Build app & sites in minutes" with a full AI team (CEO, Designer, Developer, Marketer & Copywriter).
 - [Creatr](https://getcreatr.com/) - "Create and deploy web apps and landing pages in seconds".
 - [Rork](https://rork.com/) - "Build any mobile app, fast" with React Native and Expo.
+- [Primio](https://primio.dev/) - Chat-based AI app builder that turns prompts into full Flutter apps for mobile and web, with live preview, an in-browser emulator, and one-click publishing to the app stores.
 - [Firebase Studio](https://studio.firebase.google.com/) - Google's agentic cloud-based development environment that helps build and ship production-quality full-stack AI apps.
 - [Napkins.dev](https://www.napkins.dev/) - Screenshot to code using Llama vision models.
 - [HeroUI Chat](https://heroui.chat/) - Generate beautiful apps regardless of your design experience.


### PR DESCRIPTION
Adds Primio to Browser-based Tools, next to Rork as a peer mobile app builder.

[Primio](https://primio.dev/) is a chat-based AI app builder that turns prompts into full Flutter apps for mobile and web, with live preview, an in-browser emulator, and one-click publishing to the app stores.