### PR TITLE
Add RapidNative to Browser-based Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Emergent](https://emergent.sh/) - Multi-agent AI app builder that plans, codes, tests, and deploys full-stack web and mobile apps autonomously.
 - [Manus](https://manus.im/) - Autonomous AI agent for end-to-end project automation, from research to deployment.
 - [Same.new](https://same.new/) - AI web builder for cloning and creating websites from descriptions.
+- [RapidNative](https://rapidnative.com/) - AI-native mobile app builder. Turns ideas, sketches, or screenshots into working React Native and Expo apps with production-ready code you can view, edit, and extend.
 
 ## IDEs and Code Editors
 


### PR DESCRIPTION
## Adding RapidNative

Submitting [RapidNative](https://rapidnative.com/) to the Browser-based Tools section.

### About
- **What:** AI-native mobile app builder. Describe or sketch your app, watch it build in real time, then ship to App Store / Play Store. Generates production-ready React Native code that can be viewed, edited, and extended.
- **Audience:** Founders, PMs, designers, freelancers, and developers prototyping mobile apps.
- **Pricing:** Freemium — 20 free credits to start.

### Fit
Sits naturally alongside existing entries like Bolt.new, Rork, Lovable, and Capacity. Specifically complements [Rork](https://rork.com/), which is also a React Native / Expo builder — RapidNative is differentiated by sketch-to-app input and real-time team collaboration during the build.

Thanks for maintaining this list!