### PR TITLE
Add Context Engineering: The Skill That Separates AI-Native Engineers

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 
 > This section displays items in reverse chronological order, with the most recent entries at the top.
 
+- [Context Engineering: The Skill That Separates AI-Native Engineers](https://lab.aidevos.ai/context-engineering) - A practitioner framework for engineering the information context that shapes AI output — covering structural, intent, state, and constraint context at three levels (per-prompt, session, and system). The realist alternative to vibe coding for production engineers.
 - [Vibe-Coding Triggered Major Outages at Amazon](https://belitsoft.com/news/vibe-coding-amazon-outage-20261003) - How GenAI-assisted changes triggered production outages.
 - [The State of Vibe Coding: A 2026 Strategic Blueprint | Keywords Studios](https://www.keywordsstudios.com/en/about-us/news-events/news/the-state-of-vibe-coding-a-2026-strategic-blueprint/)
 - [How Vibe Coding Is Killing Open Source | Hackaday](https://hackaday.com/2026/02/02/how-vibe-coding-is-killing-open-source/)


### PR DESCRIPTION
## What this adds

Adds **[Context Engineering: The Skill That Separates AI-Native Engineers](https://lab.aidevos.ai/context-engineering)** to the **News and Social Media** section.

## Why it fits

This article offers a practitioner's realist framework for the post-vibe-coding era — the actual skill that separates engineers who thrive with AI from those who don't. 

It names and structures **four context types** (structural, intent, state, constraint) across **three levels** (per-prompt, session, system) — the information architecture skill that production-grade AI engineering requires, and that vibe coding intentionally skips.

Given that this list already includes critical perspectives (Red Hat's 'uncomfortable truth', The New Stack's 'catastrophic explosions', Hackaday's 'killing open source'), this article complements those by offering the constructive engineer's response: not a rejection of AI-assisted development, but a rigorous framework for doing it well at scale.

**Placement:** Top of News and Social Media (reverse chronological, May 2026).