### PR TITLE
Add BuilderStudio to vibe coding tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 
 ## Browser-based Tools
 
+* [BuilderStudio](https://builderstudio.dev) - Native macOS agentic coding workspace from WunderCorp for secure local/cloud AI development, reusable Skills and Pathways, MCP integrations, Hermes-powered container-only execution, Agentic Swarms for parallel specialized agents, app previews, terminal workflows, packaging/deployment, and flexible routing across 380+ AI models.
+
+
 - [Bolt.new](https://bolt.new/) - Prompt, run, edit, and deploy full-stack web and mobile apps.
 - 🔥 [Lovable](https://lovable.dev/) - "Idea to app in seconds. Lovable is your superhuman full stack engineer".
 - [v0 by Vercel](https://v0.dev/chat) - Vibe coding platform for building production apps and agents with Next.js.


### PR DESCRIPTION
## Description

Adds BuilderStudio by WunderCorp to this curated list.

BuilderStudio is a native macOS agentic coding workspace for builders and teams that want to create software locally and securely without being locked into a single AI provider. It combines AI coding agents, reusable Skills, guided Pathways, MCP integrations, local/cloud execution, terminal workflows, app previews, packaging/deployment support, Hermes-powered contained execution, Agentic Swarms for parallel specialized agents, and flexible routing across 380+ AI models.

## Why it fits

- Native macOS workspace for local-first agentic development.
- Hermes-powered contained execution for safer local agent runs.
- Agentic Swarms for running multiple specialized Hermes lanes in parallel through Colima/Docker.
- Reusable Skills and guided Pathways for repeatable AI development workflows.
- MCP integrations, workflow creator UI, app previews, source editing, terminal workflows, packaging, and deployment support.
- Flexible routing across 380+ AI models instead of locking teams into one provider.

## Verification

This is a Markdown/list-entry-only contribution. I checked that the entry uses public BuilderStudio links and follows the target repository's existing curated-list style as closely as possible.

## Checklist

- [x] This PR is a Markdown/list-entry-only BuilderStudio submission.
- [x] The entry uses public links for BuilderStudio and BuilderStudio Skills.

## Links

- Website: https://builderstudio.dev
- Skills catalog: https://github.com/wundercorp/builderstudio-skills
- WunderCorp on X: https://x.com/wundercorp

## Links

- Website: https://builderstudio.dev
- Skills catalog: https://github.com/wundercorp/builderstudio-skills
- WunderCorp on X: https://x.com/wundercorp
