### PR TITLE
Add Huiyu-Pi to Browser-based Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Emergent](https://emergent.sh/) - Multi-agent AI app builder that plans, codes, tests, and deploys full-stack web and mobile apps autonomously.
 - [Manus](https://manus.im/) - Autonomous AI agent for end-to-end project automation, from research to deployment.
 - [Same.new](https://same.new/) - AI web builder for cloning and creating websites from descriptions.
-- [Huiyu-Pi](https://github.com/huiyu9144/Huiyu-Pi) - Local-first AI coding agent with pure Web UI. ~80 token system prompt, ~0.3s first token, 90%+ lower cost. Self-hosted, supports Claude/GPT/DeepSeek/Gemini. One command to start (npx pi-forge).
+- [Huiyu-Pi](https://github.com/huiyu9144/Huiyu-Pi) - Open-source local-first AI coding agent with pure Web UI. ~80 token system prompt, ~0.3s first token, 90%+ lower cost. Free self-hosted, supports Claude/GPT/DeepSeek/Gemini. One command to start (npx pi-forge).
 
 ## IDEs and Code Editors
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Awesome Vibe Coding [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) <!-- omit in toc -->
+﻿# Awesome Vibe Coding [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) <!-- omit in toc -->
 
 > A curated list of vibe coding references, collaborating with AI to write code.
 
@@ -50,6 +50,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Emergent](https://emergent.sh/) - Multi-agent AI app builder that plans, codes, tests, and deploys full-stack web and mobile apps autonomously.
 - [Manus](https://manus.im/) - Autonomous AI agent for end-to-end project automation, from research to deployment.
 - [Same.new](https://same.new/) - AI web builder for cloning and creating websites from descriptions.
+- [Huiyu-Pi](https://github.com/huiyu9144/pi-forge) - Local-first AI coding agent with pure Web UI. ~80 token system prompt, ~0.3s first token, 90%+ lower cost. Self-hosted, supports Claude/GPT/DeepSeek/Gemini. One command to start (npx pi-forge).
 
 ## IDEs and Code Editors
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Emergent](https://emergent.sh/) - Multi-agent AI app builder that plans, codes, tests, and deploys full-stack web and mobile apps autonomously.
 - [Manus](https://manus.im/) - Autonomous AI agent for end-to-end project automation, from research to deployment.
 - [Same.new](https://same.new/) - AI web builder for cloning and creating websites from descriptions.
-- [Huiyu-Pi](https://github.com/huiyu9144/pi-forge) - Local-first AI coding agent with pure Web UI. ~80 token system prompt, ~0.3s first token, 90%+ lower cost. Self-hosted, supports Claude/GPT/DeepSeek/Gemini. One command to start (npx pi-forge).
+- [Huiyu-Pi](https://github.com/huiyu9144/Huiyu-Pi) - Local-first AI coding agent with pure Web UI. ~80 token system prompt, ~0.3s first token, 90%+ lower cost. Self-hosted, supports Claude/GPT/DeepSeek/Gemini. One command to start (npx pi-forge).
 
 ## IDEs and Code Editors
 


### PR DESCRIPTION
Add Huiyu-Pi to Browser-based Tools section. Open-source local-first AI coding agent with pure Web UI, featuring ~80 token system prompt, ~0.3s first token latency, 90%+ lower cost. Free self-hosted, supports Claude/GPT/DeepSeek/Gemini. One command to start: npx pi-forge.

https://github.com/huiyu9144/Huiyu-Pi