### PR TITLE
Add ux-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Cody](https://sourcegraph.com/cody) - Free AI code assistant by Sourcegraph with deep codebase understanding and code indexing.
 - [Qodo Gen](https://www.qodo.ai/) - AI-powered coding platform for VS Code with testing, code review, and agentic tools.
 - [Skills.sh](https://skills.sh/) - Open ecosystem by Vercel for installing reusable AI agent skills with a single command across 18+ platforms.
+- [ux-skill](https://github.com/Laith0003/ux-skill) - Design-intelligence layer that drops into 17 AI coding tools so vibe-coded UI stops looking generic. Recommends a full design system from a brief and lints the output against 152 anti-slop rules, fully offline.
 
 ## Local Apps
 


### PR DESCRIPTION
Adds [ux-skill](https://github.com/Laith0003/ux-skill) to **Plugins and Extensions**, next to Superdesign.dev and Skills.sh.

**Why it's awesome for vibe coding:** the single most common tell of vibe-coded UI is that it reads as AI-built within five seconds (purple-to-blue gradients, three equal cards, Inter at display size, default 300ms transitions, bouncing-arrow CTAs). ux-skill is a design-intelligence layer that drops into 17 AI coding tools and replaces that improvisation with structured constraints: you capture a brief, it recommends a complete design system (style, palette, type pairing, motion, components), generates the code, then lints the output against 152 deterministic anti-slop rules before you commit. It is offline, deterministic, MIT, and never calls an LLM, so it adds zero cost and zero latency to a vibe-coding loop.

`pip install uxskill` · Site: https://uxskill.laithjunaidy.com

Follows the contribution guidelines: single suggestion, added to the bottom of the relevant category, format `- [Resource Name](link) - Description.`