### PR TITLE
Add CoderPlan — LLM API Gateway for Vibe Coding Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [superagent-ai/grok-cli](https://github.com/superagent-ai/grok-cli) - Command-line interface for AI-powered coding assistance.
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
+- [CoderPlan](https://coderplan.ai) - LLM API gateway for vibe coding tools. OpenAI-compatible endpoint for Claude Code, Cursor, Codex CLI, and other AI coding agents with pay-per-use pricing and free tier.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
 
 ## Task Management for AI Coding


### PR DESCRIPTION
## CoderPlan — LLM API Gateway for Vibe Coding

Added CoderPlan to the **Command Line Tools** section.

**URL:** https://coderplan.ai  
OpenAI-compatible API gateway for vibe coding tools (Claude Code, Cursor, Codex CLI, Cline). Pay-per-use with free tier.

Happy to adjust placement. Thanks!