### PR TITLE
Add the-perfect-orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator) - One lead Claude Code session commands N autonomous workers in tmux, with adversarial verification of results. Pure bash and tmux, zero daemons.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
Adds [the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator) to the bottom of Command Line Tools.

Why it's awesome: one lead Claude Code session spawns, briefs, monitors and adversarially verifies N autonomous worker sessions in tmux — pure bash + tmux, zero daemons, coordination via plain files. MIT.

Full disclosure: new project (v0.2.0, days old), I'm the author. Recorded real fleet run with raw transcripts: [docs/realrun-2026-06-06](https://github.com/daman8271/the-perfect-orchestrator/tree/main/docs/realrun-2026-06-06).