### PR TITLE
Add WithVibe to Local Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
+- [WithVibe](https://github.com/withvibe/withvibe) - Self-hostable shared AI workspace for teams. Anyone vibe-codes in an isolated env, the team reviews it live, and an automated agent gate (security, code review, tests, policy) runs before merge.
 
 ## Command Line Tools
 


### PR DESCRIPTION
Adds **WithVibe**, a self-hostable, source-available shared AI dev environment for teams: anyone spins up an isolated env and vibe-codes with AI, the whole team reviews it live, and an automated agent gate (security, code review, tests, policy) runs before anything merges.

Fits the **Local Apps** section alongside Dyad / bolt.diy / Superset (tools you self-host and run yourself).

Repo: https://github.com/withvibe/withvibe

- [x] One project, one line
- [x] Kept the existing format
- [x] Added under Local Apps