### PR TITLE
Add HagiCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
+- [HagiCode](https://hagicode.com/) - Local-first AI coding workspace with proposal workflows, parallel multi-agent execution, and multi-repository coordination.
 
 ## Command Line Tools
 


### PR DESCRIPTION
## Summary\n- add HagiCode to the Local Apps section\n- describe it as a local-first AI coding workspace with proposal workflows, parallel multi-agent execution, and multi-repository coordination\n\n## Why here\nHagiCode fits the local desktop app / AI coding workspace angle of the list rather than a single CLI or editor plugin.