### PR TITLE
Add Novu Connect to Command Line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [Novu Connect](https://novu.co/connect) - Communication infrastructure (ACI) for AI agents: one CLI (npx novu connect) to let your vibe-coded app reach users across Slack, WhatsApp, email & more.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
Adding **Novu Connect** to the Command Line Tools section.

Novu Connect is communication infrastructure for AI agents: one CLI (`npx novu connect`) to let your vibe-coded app reach users across Slack, WhatsApp, email and more. Open source.

- Website: https://novu.co/connect
- Source: https://github.com/novuhq/novu