### PR TITLE
Add Playcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Emergent](https://emergent.sh/) - Multi-agent AI app builder that plans, codes, tests, and deploys full-stack web and mobile apps autonomously.
 - [Manus](https://manus.im/) - Autonomous AI agent for end-to-end project automation, from research to deployment.
 - [Same.new](https://same.new/) - AI web builder for cloning and creating websites from descriptions.
+- [Playcode](https://playcode.io/ai-website-builder) - AI website and app builder with visual editing, hosting, and custom domains.
 
 ## IDEs and Code Editors
 


### PR DESCRIPTION
Adds Playcode to Browser-based Tools. It fits next to the prompt-based app and site builders already listed there.

Checks:
- Added one README entry only
- Kept the existing entry format
- Ran git diff --check