### PR TITLE
Add ax

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [ax](https://github.com/Necmttn/ax) - Local telemetry for AI coding agents.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
Adds ax to Command Line Tools.

Resource: https://github.com/Necmttn/ax

Why it is useful: ax gives AI coding workflows a local telemetry and recall layer for reviewing sessions, tool calls, skills, cost, and MCP-accessible history across Claude Code, Codex, Cursor, OpenCode, and Pi.

Checks run:

- `git diff --check`
- Added GitHub link returns 200
- `npx -y markdownlint-cli2 README.md` remains at the existing 109 MD013 line-length errors from the clean checkout

---

_Generated with [ax](https://github.com/Necmttn/ax)._