### PR TITLE
Add Tintpad (Local Apps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
+- [Tintpad](https://github.com/sorkila/tintpad) - Native macOS hotkey palette — ⌘Tab for repos — that opens your terminal at the right repository with a coding agent (Claude Code, Codex, or any CLI agent) already running. Frecency-ranked repos, per-repo launch memory, git worktree launches.
 
 ## Command Line Tools
 


### PR DESCRIPTION
Adds **Tintpad**, a native macOS menu-bar launcher: a hotkey opens your terminal at the right repo with Claude Code, Codex, or any agent already running. Frecency repo search, run modes, git worktrees, headless dispatch. Local-only, free, MIT, signed + notarized. https://github.com/sorkila/tintpad

Fits alongside Superset / Parallel Code in Local Apps. Thanks!