### PR TITLE
Add LoopTroop

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
+- [LoopTroop](https://github.com/looptroop-ai/LoopTroop) - Local, open-source GUI that takes a coding ticket from plan to PR. An LLM council plans, work runs in isolated git worktrees, and a Ralph loop resets the worktree and retries on failure to fight context rot. Built on OpenCode.
 
 ## Command Line Tools
 


### PR DESCRIPTION
I added LoopTroop under Local Apps.

It's a local, open-source GUI I've been building that takes a coding ticket all the way from plan to a reviewable PR. An LLM council plans the work first, the work runs in isolated git worktrees, and a Ralph loop resets the worktree and retries from clean context when a run goes wrong, so it doesn't drown in context rot on long tasks. It's built on OpenCode.

Felt like a good fit right next to Superset and Parallel Code since they're all local apps doing agent orchestration with git worktree isolation. One entry at the end of the section, matching the existing line format.

Repo: https://github.com/looptroop-ai/LoopTroop