### PR TITLE
Add SayCraft to Browser-based Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Emergent](https://emergent.sh/) - Multi-agent AI app builder that plans, codes, tests, and deploys full-stack web and mobile apps autonomously.
 - [Manus](https://manus.im/) - Autonomous AI agent for end-to-end project automation, from research to deployment.
 - [Same.new](https://same.new/) - AI web builder for cloning and creating websites from descriptions.
+- [SayCraft](https://saycraft.ai) - Build a working web app by talking through a meeting; the whole team speaks and AI builds it live with a shareable preview URL.
 
 ## IDEs and Code Editors
 


### PR DESCRIPTION
Adds **SayCraft** to the Browser-based Tools section.

SayCraft is a vibe-coding tool with a different input model: instead of one person typing prompts, your team opens a meeting and *talks* through what to build, and the AI builds a working web app live with a shareable preview URL (multiplayer, conversation-driven).

- Site: https://saycraft.ai
- Entry follows the section's `- [Name](url) - Description.` format.