### PR TITLE
Add VibeKit to Mobile Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 ## Mobile Apps
 
 - [VibeCode](https://www.vibecodeapp.com/) - The app that builds apps. Available on iOS and Android.
+- [VibeKit](https://apps.apple.com/us/app/vibekit-agent-devops/id6760206636) - Build, host, and continuously improve full apps from your phone — each app gets its own persistent AI coding agent with a GitHub repo, database, and live domain. Native iOS, Telegram, or CLI.
 
 ## Plugins and Extensions
 


### PR DESCRIPTION
Adds **VibeKit** (https://vibekit.bot) to the **Mobile Apps** section.

VibeKit gives every app its own persistent AI coding agent that builds, hosts, and keeps improving it over time — with a GitHub repo, a database, and a live domain included — all driven from your phone (native iOS), Telegram, or CLI.

**Note on the name:** this is distinct from the existing `superagent-ai/vibekit` entry under *Command Line Tools* (an open-source toolkit). This one is a hosted, phone-first app-builder product — hence the Mobile Apps section and the App Store link.

Disclosure: I am the maker. Happy to adjust the wording or placement to fit the list. Thanks for maintaining it!
