### PR TITLE
Add VibeKit.bot to Mobile Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 ## Mobile Apps
 
 - [VibeCode](https://www.vibecodeapp.com/) - The app that builds apps. Available on iOS and Android.
+- [VibeKit.bot](https://vibekit.bot/) - A persistent AI agent that builds, deploys, and maintains full-stack apps for you, driven from your phone. The agent runs on hosted containers (not your device), so each app ships to a live URL; bring-your-own-key for Claude/OpenAI. Native iOS + web.
 
 ## Plugins and Extensions
 


### PR DESCRIPTION
Adding **VibeKit.bot** to the **Mobile Apps** section.

VibeKit gives every app its own persistent AI agent that builds, deploys, and maintains the app over time — driven from your phone. The agent runs on hosted containers (not your device), so each app ships to a live URL and keeps running 24/7; bring-your-own-key for Claude/OpenAI, native iOS app + web dashboard.

- Site: https://vibekit.bot/
- Listed as **VibeKit.bot** to disambiguate from the unrelated `superagent-ai/vibekit` SDK.

Entry format matches the surrounding items. Thanks for maintaining the list!