### PR TITLE
Add Orca

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 ## Mobile Apps
 
 - [VibeCode](https://www.vibecodeapp.com/) - The app that builds apps. Available on iOS and Android.
+- [Orca](https://onorca.dev) - Mobile companion (iOS/Android) for Orca — monitor and control your parallel AI coding agents from your phone.
 
 ## Plugins and Extensions
 
@@ -95,6 +96,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
+- [Orca](https://onorca.dev) - An open-source desktop IDE for running parallel AI coding agents (Claude Code, Codex, Cursor, Gemini, OpenCode), each in its own isolated git worktree.
 
 ## Command Line Tools
 


### PR DESCRIPTION
Adds **Orca** to `Local Apps` and `Mobile Apps`.

Orca is an open-source (MIT) desktop IDE/ADE (macOS/Windows/Linux) with an iOS/Android companion, for running a fleet of parallel AI coding agents — Claude Code, Codex, Cursor, Gemini, OpenCode and others — each in its own isolated git worktree, with a built-in terminal, source control, and SSH.

- Source: https://github.com/stablyai/orca
- Website: https://onorca.dev

Added a desktop entry under Local Apps and a companion entry under Mobile Apps, matching the existing format. Thanks!