### PR TITLE
Add Claudescope

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [Claudescope](https://github.com/vladar107/claudescope) - Local, read-only CLI + web UI to browse, search, and analyze your AI coding-agent transcripts (Claude Code, Codex, Junie, pi, opencode, Copilot CLI). Sessions merged by working directory, with full-text search and token-cost analytics.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
Adds **[Claudescope](https://github.com/vladar107/claudescope)** to the bottom of *Command Line Tools*.

Claudescope is a local, read-only CLI (`claudescope start`) that serves a web UI to browse, read, search, and analyze your AI coding-agent transcripts across Claude Code, Codex, Junie, pi, opencode, and Copilot CLI. Sessions are merged by working directory; it adds full-text search (DuckDB) and token-cost analytics. Single npm package, MIT, cross-platform.

It's a companion/observability utility for people who vibe-code with these agents — same category as the existing `onWatch` and `pyscn` entries in this section.