### PR TITLE
Add Skill Hub — 5800+ AI Agent Skills Navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Vibe Engineering](https://www.manning.com/books/vibe-engineering)
 - [Mysti](https://github.com/DeepMyst/Mysti) - Multi-agent AI coding assistant for VS Code. Claude Code, Codex, Gemini, and GitHub Copilot brainstorm together and deliver collaborative solutions.
 
+- [Skill Hub](https://skill.442595.xyz/) — 5800+ curated AI Agent Skills for Claude Code, Codex, Cursor, Hermes & more across 22 categories.
+
 ## Contribute
 
 Contributions welcome! Read the [contribution guidelines](CONTRIBUTING.md) first.


### PR DESCRIPTION
Add [Skill Hub](https://skill.442595.xyz/) — a free directory of 5800+ curated AI agent skills for Claude Code, Codex, Cursor, Hermes, OpenClaw & more across 22 categories.