### PR TITLE
Add Proliferate to Local Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 
 - 🔥 [Dyad](https://www.dyad.sh/) - Free, local, open-source AI app builder. Model-agnostic, supports cloud models and local via Ollama.
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
+- [Proliferate](https://github.com/proliferate-ai/proliferate) - Open-source local and cloud agent IDE for running Claude Code, Codex, Gemini CLI, and other coding agents in parallel across isolated workspaces.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
 


### PR DESCRIPTION
Adds Proliferate under `Local Apps` as an open-source local and cloud agent IDE for running Claude Code, Codex, Gemini CLI, and other coding agents in parallel across isolated workspaces.