### PR TITLE
Add octomux to Local Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
+- [octomux](https://github.com/ShreyPaharia/octomux) - Local dashboard for running parallel Claude Code and Cursor agents, each in its own git worktree, with a unified permission inbox, a live monitor grid, and in-app diff review. Local-first, MIT.
 
 ## Command Line Tools
 


### PR DESCRIPTION
Adds [octomux](https://github.com/ShreyPaharia/octomux) to **Local Apps** — a local dashboard for running parallel Claude Code and Cursor agents in isolated git worktrees, with a permission inbox, monitor grid, and in-app diff review (same category as Superset / Parallel Code). Local-first, MIT.