### PR TITLE
Add Tree Ring Memory

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -127,6 +127,7 @@
 - [OpenCode](https://opencode.ai/) - 开源终端AI编程代理，支持LSP、75+个LLM提供商和多会话工作流。
 - [onWatch](https://github.com/onllm-dev/onwatch) - 开源Go CLI，跟踪7个提供商（Anthropic、OpenAI、GitHub Copilot、MiniMax等）的AI API配额使用情况。支持Claude Code、Codex CLI、Cursor、Cline等氛围编程工具。后台守护进程，<50MB内存，零遥测。
 - [pyscn](https://github.com/ludo-technologies/pyscn) - 氛围编程Python代码质量分析器。检测死代码、克隆、复杂性问题和耦合问题，具有MCP集成以支持AI助手。
+- [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) - 面向AI编程代理的框架无关Rust CLI记忆层，支持回忆、遗忘、审计和TUI工作流。
 
 ## AI编程任务管理
 

--- a/README-JP.md
+++ b/README-JP.md
@@ -127,6 +127,7 @@
 - [OpenCode](https://opencode.ai/) - LSPサポート、75以上のLLMプロバイダー、マルチセッションワークフローを備えたオープンソースのターミナルAIコーディングエージェント。
 - [onWatch](https://github.com/onllm-dev/onwatch) - 7つのプロバイダー（Anthropic、OpenAI、GitHub Copilot、MiniMaxなど）のAI APIクォータ使用量を追跡するオープンソースGo CLI。Claude Code、Codex CLI、Cursor、Clineなどのバイブコーディングツールに対応。バックグラウンドデーモン、50MB未満のRAM、テレメトリーなし。
 - [pyscn](https://github.com/ludo-technologies/pyscn) - バイブコーディングされたPythonのコード品質アナライザー。デッドコード、クローン、複雑性の問題、結合の問題を検出し、AIアシスタント向けMCP統合を提供。
+- [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) - AIコーディングエージェント向けのフレームワーク非依存Rust CLIメモリ層。リコール、忘却、監査、TUIワークフローを備えています。
 
 ## AIコーディングタスク管理
 

--- a/README-KR.md
+++ b/README-KR.md
@@ -127,6 +127,7 @@
 - [OpenCode](https://opencode.ai/) - LSP 지원, 75개 이상의 LLM 제공업체 및 멀티세션 워크플로를 갖춘 오픈소스 터미널 AI 코딩 에이전트.
 - [onWatch](https://github.com/onllm-dev/onwatch) - 7개 제공자(Anthropic, OpenAI, GitHub Copilot, MiniMax 등)의 AI API 쿼터 사용량을 추적하는 오픈소스 Go CLI. Claude Code, Codex CLI, Cursor, Cline 등 바이브 코딩 도구와 호환. 백그라운드 데몬, <50MB RAM, 텔레메트리 없음.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - 바이브 코딩된 Python 코드 품질 분석기. 데드 코드, 클론, 복잡성 문제, 결합도 문제를 감지하며 AI 어시스턴트를 위한 MCP 통합을 지원.
+- [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) - AI 코딩 에이전트를 위한 프레임워크 독립 Rust CLI 메모리 계층으로, 회상, 망각, 감사, TUI 워크플로를 지원합니다.
 
 ## AI 코딩 작업 관리
 

--- a/README-PT.md
+++ b/README-PT.md
@@ -127,6 +127,7 @@
 - [OpenCode](https://opencode.ai/) - Agente de codificação com IA de código aberto para o terminal com suporte a LSP, 75+ provedores de LLM e fluxos de trabalho multi-sessão.
 - [onWatch](https://github.com/onllm-dev/onwatch) - CLI Go de código aberto que rastreia o uso de cota de API de IA em 7 provedores (Anthropic, OpenAI, GitHub Copilot, MiniMax e mais). Funciona com Claude Code, Codex CLI, Cursor, Cline e outras ferramentas de vibe coding. Daemon em background, <50MB RAM, zero telemetria.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Analisador de qualidade de código para Python vibe-coded. Detecta código morto, clones, problemas de complexidade e acoplamento com integração MCP para assistentes de IA.
+- [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) - Camada de memória CLI em Rust, agnóstica a frameworks, para agentes de codificação com IA, com recall, esquecimento, auditoria e fluxos TUI.
 
 ## Gerenciamento de Tarefas para Codificação com IA
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [Tree Ring Memory](https://github.com/TerminallyLazy/Tree-Ring-Memory) - Framework-agnostic Rust CLI memory layer for AI coding agents with recall, forgetting, audit, and TUI workflows.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
## Why it's awesome

Tree Ring Memory is a framework-agnostic Rust CLI memory layer for AI coding agents. It gives agents local recall, forgetting, audit, and TUI workflows, and works alongside tools like Claude Code, Codex, and Gemini rather than replacing them.

## Changes

- Added Tree Ring Memory to Command Line Tools.
- Kept the English, Portuguese, Chinese, Japanese, and Korean README mirrors in sync.