### PR TITLE
Add AgentBox to Local Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
+- [AgentBox](https://github.com/madarco/agentbox) - Run multiple coding agents (Claude Code, Codex, OpenCode) in parallel, each teleported into its own sandboxed VM — local Docker, self-hosted, or cloud (Hetzner, Daytona, Vercel, E2B). Sub-1s checkpoints, per-box browser/VS Code/shells, native macOS menu-bar app; git credentials kept on the host.
 
 ## Command Line Tools
 


### PR DESCRIPTION
Adds [AgentBox](https://github.com/madarco/agentbox) to **Local Apps**, alongside Superset and Parallel Code.

AgentBox runs multiple coding agents (Claude Code, Codex, OpenCode) in parallel, each teleported into its own sandboxed VM — local Docker, self-hosted, or cloud (Hetzner, Daytona, Vercel, E2B). Sub-1s checkpoint startup, per-box browser / VS Code / persistent shells, and a native macOS menu-bar app. Git credentials stay on the host. MIT, npm `@madarco/agentbox`.