### PR TITLE
Add AiWiki — AI-coding pitfalls & LLM privacy encyclopedia, written from the AI's first-person POV

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [EnzeD/vibe-coding](https://github.com/EnzeD/vibe-coding) - The Ultimate Guide to Vibe Coding with best practices and tips.
 - [Claude Code Organizer](https://github.com/mcpware/claude-code-organizer) - Visual dashboard and MCP server to organize Claude Code memories, skills, MCP servers, and hooks with scope hierarchy and drag-and-drop.
 - 🔥 [getdesign.md](https://getdesign.md/) - Browsable library of DESIGN.md files curated from real websites.
+- - [AiWiki](https://xuebinma.github.io/AIWiki/) - An encyclopedia of AI-coding pitfalls and best practices, written from the AI's first-person perspective; 76 entries across the software lifecycle covering Claude Code, Cursor, Copilot, Codex CLI, and Gemini CLI, with a CVE-backed case library (bilingual EN/中文).
 
 ## Communities & Job Boards
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [EnzeD/vibe-coding](https://github.com/EnzeD/vibe-coding) - The Ultimate Guide to Vibe Coding with best practices and tips.
 - [Claude Code Organizer](https://github.com/mcpware/claude-code-organizer) - Visual dashboard and MCP server to organize Claude Code memories, skills, MCP servers, and hooks with scope hierarchy and drag-and-drop.
 - 🔥 [getdesign.md](https://getdesign.md/) - Browsable library of DESIGN.md files curated from real websites.
-- - [AiWiki](https://xuebinma.github.io/AIWiki/) - An encyclopedia of AI-coding pitfalls and best practices, written from the AI's first-person perspective; 76 entries across the software lifecycle covering Claude Code, Cursor, Copilot, Codex CLI, and Gemini CLI, with a CVE-backed case library (bilingual EN/中文).
+- [AiWiki](https://xuebinma.github.io/AIWiki/en/) - An engineering encyclopedia written from the AI's first-person perspective, in two subjects: AI-coding pitfalls (76 entries across the software lifecycle, covering Claude Code, Cursor, Copilot, Codex CLI, and Gemini CLI, with a CVE-backed case library) and LLM privacy protection (bilingual EN/中文).
 
 ## Communities & Job Boards
 


### PR DESCRIPTION
## What is this?

[AiWiki](https://xuebinma.github.io/AIWiki/en/) is an engineering encyclopedia written from the AI's own first-person perspective — "here's what I, the model, see you doing," rather than a detached how-to. Fully bilingual (EN/中文), licensed CC BY-SA 4.0.

Two subjects:

- **AI-coding pitfalls** — 76 entries across the 8 phases of the software lifecycle, comparing 5 coding tools (Claude Code, Cursor, Copilot, Codex CLI, Gemini CLI), with a CVE-backed real-incident case library and a cross-tool matrix.
- **LLM privacy protection** — how sensitive data leaks from LLM systems and how to defend it, organized along LLM history: mechanisms + actionable recipes + real incidents.

Repo: https://github.com/XuebinMa/AIWiki

## Why it fits

Every entry tags its evidence (official docs / arXiv / CVE & security advisories) and is version-stamped — practical guardrails for vibe coding, not vibes about vibe coding.

Added under **Documentation for AI Coding**, following the existing entry format.
