### PR TITLE
Add DevIntern

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [CCPM (Claude Code PM)](https://github.com/automazeio/ccpm) - Project management for Claude Code using GitHub Issues and Git worktrees for parallel agent execution.
 - [Archon](https://github.com/coleam00/Archon) - Knowledge and task management backbone for AI coding assistants via MCP.
 - [AI-DLC Workflows (AWS Labs)](https://github.com/awslabs/aidlc-workflows) - AI-Driven Development Life Cycle workflow rules for coding agents. Supports Kiro, Q Developer, Cursor, Cline, Claude Code.
+- [DevIntern](https://github.com/getdevintern/devintern) - Turns tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files into self-reviewed pull requests using the coding agent of your choice, on your machines with your own model keys. Companion devpm tool creates codebase-grounded tickets from rough prompts, logs, or Figma frames.
 
 ## Documentation for AI Coding
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [CCPM (Claude Code PM)](https://github.com/automazeio/ccpm) - Project management for Claude Code using GitHub Issues and Git worktrees for parallel agent execution.
 - [Archon](https://github.com/coleam00/Archon) - Knowledge and task management backbone for AI coding assistants via MCP.
 - [AI-DLC Workflows (AWS Labs)](https://github.com/awslabs/aidlc-workflows) - AI-Driven Development Life Cycle workflow rules for coding agents. Supports Kiro, Q Developer, Cursor, Cline, Claude Code.
-- [DevIntern](https://github.com/getdevintern/devintern) - Turns tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files into self-reviewed pull requests using the coding agent of your choice, on your machines with your own model keys. Companion devpm tool creates codebase-grounded tickets from rough prompts, logs, or Figma frames.
+- [DevIntern](https://github.com/getdevintern/devintern) - Turns tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files into self-reviewed pull requests using the coding agent of your choice, on your machines with your own model keys. Companion devpm tool creates codebase-grounded tickets from rough prompts.
 
 ## Documentation for AI Coding
 


### PR DESCRIPTION
Adds [DevIntern](https://github.com/getdevintern/devintern) to the Task Management for AI Coding section.

DevIntern (https://devintern.com/, docs: https://devintern.com/docs) picks up tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files and turns them into self-reviewed pull requests using the coding agent of your choice (Claude Code, Codex, Cursor, OpenCode, Gemini CLI, and others), running on your machines with your own model keys. A feasibility gate flags vague tickets back to the tracker with questions, and an optional unattended mode schedules ticket pickup and turns PR review comments into commits. The companion devpm tool creates well-specified, codebase-grounded tickets from rough prompts, logs, or Figma frames, which is why it fits this section. Source-available under FSL-1.1, free for interactive use.

I'm the author. Followed the contribution guidelines: single suggestion, entry format matched, added to the bottom of the category.