### PR TITLE
Add LLMGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Emergent](https://emergent.sh/) - Multi-agent AI app builder that plans, codes, tests, and deploys full-stack web and mobile apps autonomously.
 - [Manus](https://manus.im/) - Autonomous AI agent for end-to-end project automation, from research to deployment.
 - [Same.new](https://same.new/) - AI web builder for cloning and creating websites from descriptions.
+- [LLMGraph](https://llmgraph.ai) - Visual builder for LLM workflows: build RAG chatbots and AI agents on a canvas or by describing them in chat, with one-click deploy to a REST API and chat widget.
 
 ## IDEs and Code Editors
 


### PR DESCRIPTION
Adds [LLMGraph](https://llmgraph.ai) to Browser-based Tools.

LLMGraph is a browser-based visual builder for LLM workflows — you build RAG chatbots and AI agents on a canvas (or by describing them in chat) and deploy them to a REST API and embeddable chat widget in one click. It fits the vibe-coding spirit: describe what you want, get a working, deployed AI app without writing code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)