### PR TITLE
Add UIZZE to Documentation for AI Coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [EnzeD/vibe-coding](https://github.com/EnzeD/vibe-coding) - The Ultimate Guide to Vibe Coding with best practices and tips.
 - [Claude Code Organizer](https://github.com/mcpware/claude-code-organizer) - Visual dashboard and MCP server to organize Claude Code memories, skills, MCP servers, and hooks with scope hierarchy and drag-and-drop.
 - 🔥 [getdesign.md](https://getdesign.md/) - Browsable library of DESIGN.md files curated from real websites.
+- [UIZZE](https://uizze.com/docs) - Give AI coding agents real UI context before they build: screenshots, flows, UI elements, MCP reference packs, design contracts, audits, and critiques.
 
 ## Communities & Job Boards
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [EnzeD/vibe-coding](https://github.com/EnzeD/vibe-coding) - The Ultimate Guide to Vibe Coding with best practices and tips.
 - [Claude Code Organizer](https://github.com/mcpware/claude-code-organizer) - Visual dashboard and MCP server to organize Claude Code memories, skills, MCP servers, and hooks with scope hierarchy and drag-and-drop.
 - 🔥 [getdesign.md](https://getdesign.md/) - Browsable library of DESIGN.md files curated from real websites.
-- [UIZZE](https://uizze.com/docs) - Give AI coding agents real UI context before they build: screenshots, flows, UI elements, MCP reference packs, design contracts, audits, and critiques.
+- [UIZZE](https://uizze.com) - Give AI coding agents real UI context before they build: screenshots, flows, UI elements, MCP reference packs, design contracts, audits, and critiques.
 
 ## Communities & Job Boards
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [EnzeD/vibe-coding](https://github.com/EnzeD/vibe-coding) - The Ultimate Guide to Vibe Coding with best practices and tips.
 - [Claude Code Organizer](https://github.com/mcpware/claude-code-organizer) - Visual dashboard and MCP server to organize Claude Code memories, skills, MCP servers, and hooks with scope hierarchy and drag-and-drop.
 - 🔥 [getdesign.md](https://getdesign.md/) - Browsable library of DESIGN.md files curated from real websites.
-- [UIZZE](https://uizze.com) - Give AI coding agents real UI context before they build: screenshots, flows, UI elements, MCP reference packs, design contracts, audits, and critiques.
+- [UIZZE](https://uizze.com) - Free anti-ui-slop Skill and deterministic preview for coding agents; full UIZZE adds live UI research across 800,000+ real web and iOS screens, design contracts, validation, audits, and rendered critique.
 
 ## Communities & Job Boards
 


### PR DESCRIPTION
## What changed

- Added UIZZE to Documentation for AI Coding.
- Linked the UIZZE homepage with a concise, free-first description of its agent-facing UI workflow.
- Updated the visible directory line to distinguish the free anti-ui-slop Skill and deterministic preview from the full product.

## Why it belongs

UIZZE gives coding agents a free anti-ui-slop Skill and deterministic preview before implementation. Full UIZZE adds live UI research across 800,000+ real web and iOS screens, design contracts, validation, audits, and rendered critique.

I build UIZZE, so this is a disclosed first-party submission. Canonical source: https://github.com/uizze/uizze

## Impact

Readers get one additional UI-focused documentation and context resource.

## Checks

- Confirmed no existing UIZZE entry or submission.
- Followed the one-resource format.
- Verified https://uizze.com returns successfully.
- Ran git diff --check.