### PR TITLE
Add Vibe Guardian (pre-commit security gate for AI-generated code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [Vibe Guardian](https://github.com/wbw20000/vibe-guardian) - Pre-commit security gate for AI-generated code: blocks hardcoded API keys, SQL/XSS injection, and Supabase RLS misconfigurations before they reach a commit. 100% local static rules, zero dependencies.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
## What
Adds **[Vibe Guardian](https://github.com/wbw20000/vibe-guardian)** to Command Line Tools.

## Why it fits this list
Vibe coding's biggest documented failure mode is security: the Moltbook breach (1.5M API keys, root cause: Supabase RLS never enabled) and scans showing ~11% of vibe-coded apps exposing Supabase credentials. Vibe Guardian is a pre-commit gate built specifically for this:

- Catches what AI assistants ship most: hardcoded secrets (OpenAI/AWS/Stripe/...), SQL injection via template strings, XSS sinks, Supabase `service_role` keys in client code, `CREATE TABLE` without RLS
- 100% local static rules — no LLM calls, no telemetry, zero npm dependencies
- Works as a plain git pre-commit hook (any editor: Cursor, Windsurf, Lovable exports) or as a Claude Code plugin that scans while the AI writes
- MIT licensed, CI green, on npm (`npx vibe-guardian scan`)

Disclosure: I'm the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)