### PR TITLE
Add VibeKit.bot to Mobile Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 ## Mobile Apps
 
 - [VibeCode](https://www.vibecodeapp.com/) - The app that builds apps. Available on iOS and Android.
+- [VibeKit.bot](https://vibekit.bot/) - Build, host, and update web apps from your phone. Each app runs a hosted AI coding agent on a live subdomain, with its code in a standard GitHub repo. BYOK Anthropic/OpenAI. Native iOS app.
 
 ## Plugins and Extensions
 


### PR DESCRIPTION
Adds **VibeKit.bot** to the Mobile Apps section, alongside VibeCode.

VibeKit.bot lets you build, host, and update web apps from your phone: each app runs a hosted AI coding agent on its own live subdomain, with the code kept in a standard GitHub repo (clone/fork/push, no lock-in). BYOK Anthropic/OpenAI, and there is a native iOS app.

It fits Mobile Apps because the whole build-and-maintain loop runs from a phone. Note this is distinct from the existing `superagent-ai/vibekit` entry under Command Line Tools (that is an unrelated sandboxing SDK that happens to share the name), which is why the entry is listed as **VibeKit.bot**.

- Format-matched one-liner, single-line diff, alphabetical-adjacent to VibeCode.
- Live: https://vibekit.bot/