### PR TITLE
Add Alpheon

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [Alpheon](https://github.com/BravoAlphaSix/alpheon) - Reads your git diff and drafts a reviewable handoff note (what changed, why, what was tried and rejected, what's next) saved as HANDOFF.md in your repo, so the reasoning behind AI-assisted changes survives after the chat session ends. Zero dependencies, tool-agnostic.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
Alpheon is a tiny, dependency-free CLI that reads your git diff and drafts a reviewable handoff note (what changed, why, what was tried and rejected, what's next) saved as HANDOFF.md in your repo.

Why it's awesome: when you vibe-code with an AI assistant, the reasoning behind a change lives in the chat session and vanishes when it ends. Alpheon captures that 'why' as plain markdown committed next to your code, so a teammate (or future you) can see why something was done. It's tool-agnostic (works off git, not tied to any one agent) and has zero dependencies.