### PR TITLE
Add Orkas to Local Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
+- [Orkas](https://github.com/Orkas-AI/Orkas) - Open-source local-first desktop workspace for running Claude Code, Codex CLI, OpenCode, Cline, and built-in agents in parallel with shared files and approval controls. [Website](https://orkas.ai?source=gh-vibe)
 
 ## Command Line Tools
 


### PR DESCRIPTION
## Summary

- Add Orkas to the Local Apps section.
- Link the open-source repository and the source-tagged project website.

Orkas is a local-first desktop workspace for running Claude Code, Codex CLI, OpenCode, Cline, and built-in agents in parallel. It provides shared files and human approval controls while keeping user data and BYO model keys local by default.

Project: https://github.com/Orkas-AI/Orkas
Website: https://orkas.ai?source=gh-vibe