### PR TITLE
Add Unpeel

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
-- [Unpeel](https://unpeel.com) - Native macOS app to run and supervise multiple CLI agent sessions (Claude Code, Codex, Gemini CLI, and more) with persistent terminals, git worktree isolation, attention notifications, and iPhone remote control.
+- [Unpeel](https://unpeel.com) - Native macOS app built on the Ghostty terminal engine to run and supervise multiple CLI agent sessions (Claude Code, Codex, Gemini CLI, and more) with persistent terminals, git worktree isolation, attention notifications, and iPhone remote control.
 
 ## Command Line Tools
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
+- [Unpeel](https://unpeel.com) - Native macOS app to run and supervise multiple CLI agent sessions (Claude Code, Codex, Gemini CLI, and more) with persistent terminals, git worktree isolation, attention notifications, and iPhone remote control.
 
 ## Command Line Tools
 


### PR DESCRIPTION
Link: https://unpeel.com

Adds Unpeel to **Local Apps** (bottom of the category, per the contributing guidelines).

Unpeel is a native macOS app to run and supervise multiple CLI agent sessions — Claude Code, Codex, Gemini CLI, Amp, OpenCode, Cline, and more. Sessions run in hosted terminals that survive app restarts, agents can be isolated in git worktrees to work the same repo in parallel (same territory as Superset / Parallel Code), the app surfaces busy/needs-attention notifications per session, and sessions can be remote-controlled from an iPhone via a self-hosted end-to-end encrypted relay. Free download (Pro subscription for remote access); closed-source; macOS beta.