### PR TITLE
Add stepback

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [stepback](https://github.com/Archerkattri/stepback) - Git time-travel for AI coding agents: checkpoint every edit from Claude Code, Codex, aider, or any command and rewind without touching your branch, HEAD, or index.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
Adds [stepback](https://github.com/Archerkattri/stepback) to Command Line Tools. It is useful for vibe-coding workflows because it checkpoints edits from any coding agent and can rewind the working tree exactly without changing the real branch, HEAD, index, staging area, or commit history.