### PR TITLE
Add PinkCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
+- [PinkCode](https://github.com/3xian/PinkCode) - Open-source desktop GUI for running multiple Grok Build coding-agent sessions in parallel, with live task timelines, usage visualizations, file-change review, and permission controls.
 
 ## Command Line Tools
 


### PR DESCRIPTION
Adds [PinkCode](https://github.com/3xian/PinkCode) to **Local Apps**.

PinkCode is an open-source desktop GUI for Grok Build that runs multiple coding-agent sessions in parallel and provides live task timelines, usage visualizations, file-change review, and permission controls. It belongs in this list because it provides a visual workflow for collaborating with a coding agent rather than replacing the underlying CLI.

Disclosure: I maintain PinkCode.