### PR TITLE
Add anti-slop-website-prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [EnzeD/vibe-coding](https://github.com/EnzeD/vibe-coding) - The Ultimate Guide to Vibe Coding with best practices and tips.
 - [Claude Code Organizer](https://github.com/mcpware/claude-code-organizer) - Visual dashboard and MCP server to organize Claude Code memories, skills, MCP servers, and hooks with scope hierarchy and drag-and-drop.
 - 🔥 [getdesign.md](https://getdesign.md/) - Browsable library of DESIGN.md files curated from real websites.
+- [anti-slop-website-prompts](https://github.com/OpenSettle/anti-slop-website-prompts) - 15 free art-directed website build-prompts and an anti-slop design SKILL.md for Lovable, Bolt, v0, Cursor, and Claude Code.
 
 ## Communities & Job Boards
 


### PR DESCRIPTION
Adds [anti-slop-website-prompts](https://github.com/OpenSettle/anti-slop-website-prompts) to **Documentation for AI Coding**.

**What it is:** 15 free, complete, art-directed website build-prompts (full text, MIT-licensed repo, commercial use OK) plus an anti-slop design `SKILL.md` for agentic tools (Claude Code, Cursor). Each prompt is a full art-direction spec — named typefaces, token-based color, structural layout, specified motion, real asset URLs — so Lovable/Bolt/v0/Cursor/Claude Code output looks designed instead of the default purple-gradient template.

**Why it's awesome:** it attacks the most common vibe-coding complaint (everything looks the same) with paste-ready specs rather than tips, and the SKILL.md distills the method into an installable skill.

Disclosure: I'm affiliated with the project (Meez, meez.design) — the linked repo and all 15 prompts are free.