### PR TITLE
Add MulmoTerminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [MulmoTerminal](https://github.com/receptron/mulmoterminal) - Browser terminal that runs multiple Claude Code and Codex sessions in a grid, colour-coded by which agent needs input, with tmux persistence, git worktree isolation and phone push.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
**Resource**: https://github.com/receptron/mulmoterminal

**Why it's awesome**

Vibe coding with one agent needs nothing but a shell. This is for the point where you run several and lose track of which one is waiting on you.

It runs multiple Claude Code and Codex sessions as real PTYs on your own machine and puts them in a browser grid, where each cell is colour-coded by state — working, waiting for input, or done — so the one that needs you is visible without visiting each pane. Sessions survive a reload through tmux, parallel work isolates in git worktrees with one-click PRs, and a finished or blocked turn can send a Web Push to your phone.

Everything runs locally: your code, your keys, your existing `claude` CLI. One command, no install:

```
npx mulmoterminal@latest
```

MIT licensed. Added to the end of **Command Line Tools** per the contributing guidelines.