### PR TITLE
Add Blume

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 
 ## Local Apps
 
+- [Blume](https://blume.codes/) - Desktop sidecar that monitors coding-agent sessions, shows the rules, skills, and hooks shaping each run, tracks usage across Claude Code, Codex, Cursor, omp, and Pi, and keeps chat history local.
 - [CCHub](https://github.com/Moresl/cchub) - Desktop app for managing the Claude Code ecosystem — MCP server marketplace, config profile switching, workflow templates, security audit, and autopilot. Built with Tauri + React + Rust.
 
 - 🔥 [Dyad](https://www.dyad.sh/) - Free, local, open-source AI app builder. Model-agnostic, supports cloud models and local via Ollama.


### PR DESCRIPTION
## What changed

Added Blume to the Local Apps section.

Blume is a desktop sidecar for coding agents. It monitors agent sessions, surfaces the rules, skills, and hooks shaping each run, tracks usage, and keeps conversation history under local control.

## Disclosure

Blume is our own product, and we use it ourselves.