### PR TITLE
Add WeInc to Browser-based Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Emergent](https://emergent.sh/) - Multi-agent AI app builder that plans, codes, tests, and deploys full-stack web and mobile apps autonomously.
 - [Manus](https://manus.im/) - Autonomous AI agent for end-to-end project automation, from research to deployment.
 - [Same.new](https://same.new/) - AI web builder for cloning and creating websites from descriptions.
+- [WeInc](https://we.inc/) - AI website builder that generates complete hosted production sites (React) from prompts; flat pricing and white-label for agencies.
 
 ## IDEs and Code Editors
 


### PR DESCRIPTION
Hi! This adds [WeInc](https://we.inc) to the Browser-based Tools section, following the existing entry format.

WeInc is an AI website builder that turns prompts into complete, hosted production sites (React), with flat pricing and white-label support for agencies — same space as Bolt.new / Lovable / Same.new already on the list.

We also maintain [awesome-ai-website-builders](https://github.com/umairalisadaqat/awesome-ai-website-builders), a curated comparison of tools in this niche. Happy to adjust wording or placement if you prefer. Thanks for maintaining this list!