### PR TITLE
Add BitFun to Local Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
+- [BitFun](https://openbitfun.com/) - Open-source desktop AI agent with a Rust runtime (Tauri v2). Works in real Git repos and can drive the browser, terminal, and desktop apps; extends via MCP, Skills, and Mini Apps.
 
 ## Command Line Tools
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
-- [BitFun](https://openbitfun.com/) - Open-source desktop AI agent with a Rust runtime (Tauri v2). Works in real Git repos and can drive the browser, terminal, and desktop apps; extends via MCP, Skills, and Mini Apps.
+- [BitFun](https://openbitfun.com/) - Open-source desktop AI agent that builds each task its own Mini App — chart, board, form — with a chat bound to that app's live state. Rust runtime, self-hostable device sync.
 
 ## Command Line Tools
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
-- [BitFun](https://openbitfun.com/) - Open-source desktop AI agent that builds each task its own Mini App — chart, board, form — with a chat bound to that app's live state. Rust runtime, self-hostable device sync.
+- [BitFun](https://openbitfun.com/) - Cross-platform desktop AI agent that builds each task its own Mini App — chart, board, form — with a chat bound to that app's live state. Rust runtime, self-hostable device sync.
 
 ## Command Line Tools
 


### PR DESCRIPTION
Adds [BitFun](https://openbitfun.com/) to `## Local Apps` using the repository's required one-line format:

`- [BitFun](https://openbitfun.com/) - Cross-platform desktop AI agent that builds each task its own Mini App — chart, board, form — with a chat bound to that app's live state. Rust runtime, self-hostable device sync.`

BitFun is relevant to this list as a cross-platform desktop workspace for AI-assisted coding and task execution. Its Agentic Mini Apps turn task output into purpose-built interactive interfaces backed by a Rust runtime, and its device-sync server can be self-hosted.

Disclosure: I'm a BitFun maintainer. BitFun's core code is MIT-licensed. Licensing and provenance for bundled third-party content are under review, so this PR does not characterize the entire bundled product as MIT-licensed or open source.
