### PR TITLE
Add Vibe Coding UI Specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [EnzeD/vibe-coding](https://github.com/EnzeD/vibe-coding) - The Ultimate Guide to Vibe Coding with best practices and tips.
 - [Claude Code Organizer](https://github.com/mcpware/claude-code-organizer) - Visual dashboard and MCP server to organize Claude Code memories, skills, MCP servers, and hooks with scope hierarchy and drag-and-drop.
 - 🔥 [getdesign.md](https://getdesign.md/) - Browsable library of DESIGN.md files curated from real websites.
+- [Vibe Coding UI Specification](https://github.com/Mdx2025/horizonx-ui/blob/main/VIBE-CODING-UI-SPEC.md) - Free specification and reusable YAML template for tokens, states, responsive behavior, accessibility, motion and production review.
 
 ## Communities & Job Boards
 


### PR DESCRIPTION
## What changed

- Added the free [Vibe Coding UI Specification](https://github.com/Mdx2025/horizonx-ui/blob/main/VIBE-CODING-UI-SPEC.md) to the bottom of **Documentation for AI Coding**.
- Kept the contribution to one README line using the required list format.

## Why it fits

The MIT-licensed resource gives vibe-coding teams a reusable YAML contract for design tokens, component states, responsive behavior, accessibility, motion and production review. It complements the existing specifications and templates in this section.

## Disclosure

I’m Marcelo Cedeño, founder of HorizonX. HorizonX is a paid commercial UI and code library; the linked specification itself is free and includes a brief maintainer attribution. AI assisted with drafting and formatting this contribution, and I personally verified the final wording, link and diff. No sponsorship, payment, reciprocal link or guaranteed placement is requested.