### PR TITLE
Add Forge Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Cody](https://sourcegraph.com/cody) - Free AI code assistant by Sourcegraph with deep codebase understanding and code indexing.
 - [Qodo Gen](https://www.qodo.ai/) - AI-powered coding platform for VS Code with testing, code review, and agentic tools.
 - [Skills.sh](https://skills.sh/) - Open ecosystem by Vercel for installing reusable AI agent skills with a single command across 18+ platforms.
+- [Forge Design](https://github.com/forge-ui/forge-design-extension) - Chrome extension + local Grok bridge: pick a component on the live page, then edit the UI. Page data stays on-device.
 
 ## Local Apps
 


### PR DESCRIPTION
Adds [Forge Design](https://github.com/forge-ui/forge-design-extension) to **Plugins and Extensions**.

Chrome extension + local Grok bridge: pick a component on the live page, then edit the UI. Page data stays on-device. MIT.

This is my own project. It is functional and documented; install is unpacked from GitHub plus a local bridge.

Why it fits: same job as browser pick-to-edit tools (click the real component, let the coding agent change it), but local-first for Grok Build.

Made with [Cursor](https://cursor.com)