### PR TITLE
Add Podbay Self-Hosted to Local Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 ## Local Apps
 
 - [CCHub](https://github.com/Moresl/cchub) - Desktop app for managing the Claude Code ecosystem — MCP server marketplace, config profile switching, workflow templates, security audit, and autopilot. Built with Tauri + React + Rust.
+- [Podbay Self-Hosted](https://github.com/podbay-cloud/install) - One-command installer that runs Claude Code in a persistent Docker workspace on your own machine or VPS, so credentials stay local while you drive the session from the official Claude apps; uses your existing Claude Pro/Max plan.
 
 - 🔥 [Dyad](https://www.dyad.sh/) - Free, local, open-source AI app builder. Model-agnostic, supports cloud models and local via Ollama.
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.


### PR DESCRIPTION
Persistent Docker workspace for Claude Code on your own machine — self-host, own Claude plan, creds stay local. Fits Local Apps alongside Superset/Parallel Code.