### PR TITLE
Add MCP Lens to Plugins and Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Cody](https://sourcegraph.com/cody) - Free AI code assistant by Sourcegraph with deep codebase understanding and code indexing.
 - [Qodo Gen](https://www.qodo.ai/) - AI-powered coding platform for VS Code with testing, code review, and agentic tools.
 - [Skills.sh](https://skills.sh/) - Open ecosystem by Vercel for installing reusable AI agent skills with a single command across 18+ platforms.
+- [MCP Lens](https://github.com/labmimors/dsh-mcp-lens) - DeepSeek Harness plugin that keeps large MCP catalogs behind search and exact-schema call interfaces.
 
 ## Local Apps
 


### PR DESCRIPTION
## What changed

- Adds MCP Lens to the end of **Plugins and Extensions** using the list's required one-line format.

## Why it fits

MCP Lens is an open-source DeepSeek Harness plugin that keeps large MCP catalogs behind search and exact-schema call interfaces. I maintain the linked project; it is a Harness plugin and MCP client, not an MCP server.

## Checks

- Confirmed the project page and `v0.1.0-rc.9` release are public and reachable.
- Searched this repository's open and closed pull requests for duplicates.
- Ran `git diff --check` and an exact-entry check.
- Compared `npx --yes awesome-lint` against `origin/main`; both report the same existing repository-level findings.
