### PR TITLE
Add DSH Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
+- [DSH Studio](https://github.com/Moresyl/dsh-studio) - Open-source cross-platform desktop app that installs, runs, health-checks, and supervises DeepSeek Harness locally.
 
 ## Command Line Tools
 


### PR DESCRIPTION
Adds [DSH Studio](https://github.com/Moresyl/dsh-studio) to **Local Apps**.

DSH Studio is an open-source desktop host for DeepSeek Harness on macOS, Windows, and Linux. It installs and starts the local harness, follows its OS-assigned port, performs real HTTP health checks, restarts it with backoff, streams logs, and cleans up the complete tool-process tree when the window exits.

It fits beside the existing local agent managers because it turns the terminal-run DeepSeek coding harness into a supervised desktop workflow while keeping the upstream harness UI unchanged.

Disclosure: this is my project. The PR adds one entry at the bottom of the relevant category, with no existing entries changed.