### PR TITLE
Add agent-qa to Command Line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [agent-qa](https://github.com/vostride/agent-qa) - Self-improving QA agent for natural-language web/mobile tests with persistent memory, CLI, MCP, and Agent Skills.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
## Summary

Adds agent-qa to **Command Line Tools**. It is an open-source, self-improving QA agent that lets software and coding agents author and run natural-language web/mobile tests through a CLI, MCP server, and Agent Skills, with persistent execution memory across runs.

## Checks

- One resource added in the requested list format
- Repository was not already listed or proposed
- Public project, documentation, npm, and license links verified
- `git diff --check` passes

Project disclosure: this submission is for agent-qa itself. Its current FSL-1.1-ALv2 license converts to Apache-2.0 after two years.
