### PR TITLE
Add UIZZE to Plugins and Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Cody](https://sourcegraph.com/cody) - Free AI code assistant by Sourcegraph with deep codebase understanding and code indexing.
 - [Qodo Gen](https://www.qodo.ai/) - AI-powered coding platform for VS Code with testing, code review, and agentic tools.
 - [Skills.sh](https://skills.sh/) - Open ecosystem by Vercel for installing reusable AI agent skills with a single command across 18+ platforms.
+- [UIZZE](https://uizze.com/) - UI reference and anti-UI-slop toolkit for coding agents, with 800,000+ real web and iOS screens, an agent skill, GitHub Action, and free MCP preview.
 
 ## Local Apps
 


### PR DESCRIPTION
## What does this PR add?

- Adds UIZZE to Plugins and Extensions.
- Describes the public 800,000+ real web and iOS UI reference library, anti-UI-slop agent skill, GitHub Action, and free MCP preview.

## Why is it useful here?

UIZZE is directly relevant to AI-assisted interface work: it gives coding agents UI reference and a quality gate for catching generic UI before it ships.

Disclosure: UIZZE is my own project.

- Product: https://uizze.com/
- Source: https://github.com/uizze/uizze
