### PR TITLE
Add Kolega Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [kolega-ai/kolega-code](https://github.com/kolega-ai/kolega-code) - Coding agent in the terminal where the model writes its own multi-agent workflows (Gigacode). Provider-agnostic, local-first, 15+ model providers, MCP client.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
Adds Kolega Code to the Command Line Tools section, at the bottom per the contribution guidelines.

Kolega Code is an open-source coding agent that runs in the terminal. The model writes its own multi-agent workflows (Gigacode) instead of following a fixed loop. It is provider-agnostic with 15+ model providers, keeps state local, and works as an MCP client. Sessions are journaled to disk, so a resume replays unchanged tool calls without spending tokens again.
