### PR TITLE
Add workspace-metabolism to Command Line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
 
+- [workspace-metabolism](https://github.com/metabolism-tools/workspace-metabolism) - Zero-dependency CLI that governs the lifecycle of AI workspace byproducts: policy-graded audit, recyclable clean, exact rollback, hash-chained audit trail.
+
 ## Task Management for AI Coding
 
 - [Boomerang Tasks](https://docs.roocode.com/features/boomerang-tasks) - Automatically break down complex projects into smaller, manageable pieces.


### PR DESCRIPTION
## Summary

Adds workspace-metabolism to **Command Line Tools**. It is a zero-dependency Python CLI that manages the lifecycle of files in AI-driven workspaces: one policy file grades every path (G1-G4), `clean` moves expired items to a recycle area instead of deleting, `rollback` is an exact verified undo, and every action lands in a hash-chained journal. It ships with a reproducible 30-loop benchmark (2 active files vs 242).

No existing entry in this list covers workspace byproduct lifecycle; the CLI section covers coding agents and code quality analyzers, but nothing manages the files those agents leave behind.

## Checks

- One resource added in the requested list format
- Repository was not already listed or proposed
- Public project, documentation, and license verified (MIT)
- `git diff --check` passes

Project disclosure: I'm the author of workspace-metabolism; this is a submission for the project itself.