### PR TITLE
Add Keen Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [Keen Code](https://mochow13.github.io/keen-code/) - Open-source, context-aware terminal coding agent written in Go with multiple providers, skill-driven MCP integration, subagents, Agent Skills, controllable tool-output retention, and hashline edits.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
## Resource

- Website: https://mochow13.github.io/keen-code/
- GitHub: https://github.com/mochow13/keen-code

## Why it is awesome

Keen Code is an open-source, context-aware terminal coding agent written in Go. It supports multiple providers, MCPs, subagents, Agent Skills, controllable tool-output retention, hashline edits, and more.

Two notable capabilities are:

- **Turn Memory:** Keen defaults to lean context for multi-turn conversations by retaining only selected tool-interaction signals across turns. Users can control how tool outputs are retained. [Learn more](https://mochow13.github.io/keen-code/docs/turn-memory.html).
- **Skill-driven MCP:** Instead of loading MCP tools upfront or relying on semantic tool search, Keen integrates MCP servers through generated Agent Skills. [Learn more](https://mochow13.github.io/keen-code/docs/mcp-skills.html).

This adds one entry to the bottom of the **Command Line Tools** section, following the requested format.