### PR TITLE
Add awesome-agentic-ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [EnzeD/vibe-coding](https://github.com/EnzeD/vibe-coding) - The Ultimate Guide to Vibe Coding with best practices and tips.
 - [Claude Code Organizer](https://github.com/mcpware/claude-code-organizer) - Visual dashboard and MCP server to organize Claude Code memories, skills, MCP servers, and hooks with scope hierarchy and drag-and-drop.
 - 🔥 [getdesign.md](https://getdesign.md/) - Browsable library of DESIGN.md files curated from real websites.
+- [awesome-agentic-ai](https://github.com/adriannoes/awesome-agentic-ai) - Learning hub of agent skills, coding rules, prompts, notebooks, and papers for shipping products with AI.
 
 ## Communities & Job Boards
 


### PR DESCRIPTION
Adds the hub under **Documentation for AI Coding**, alongside awesome-ralph, getdesign.md, and awesome-cursorrules.

https://github.com/adriannoes/awesome-agentic-ai

This list already bridges vibe coding → agentic engineering. The hub is a maintained collection (skills, rules, PM/spec templates, learning track) for product builders using Cursor, Claude Code, and Codex — not a single tool or SaaS.

MIT. First published Oct 2025. Links checked. One item.