### PR TITLE
Add CommitLore

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [CommitLore](https://github.com/MongLong0214/commitlore) - Git-native decision memory for coding agents. Stores constraints and ruled-out alternatives as git trailers and refs/notes, returning only records still in force for the file being edited.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
Adds CommitLore to the Command Line Tools list. CommitLore is a git-native decision memory tool for coding agents that stores constraints and ruled-out alternatives as git trailers and refs/notes, returning only the records still in force for the file being edited.