### PR TITLE
Add amtr

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [amtr](https://github.com/arian-shamaei/anthropometer) - btop-style context monitor for AI coding agents (Claude Code, Codex CLI): live context-window map, per-file token accounting, and cache economics in a ratatui TUI.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
Adds [amtr](https://github.com/arian-shamaei/anthropometer) to Command Line Tools - a btop-style context monitor for AI coding agents (Claude Code, Codex CLI): live context-window map, per-file token accounting, and cache economics in a ratatui TUI. Follows the section entry format.