### PR TITLE
feat: add agent-operator-score

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [agent-operator-score](https://github.com/MongLong0214/agent-operator-score) - Local-first CLI (`aos`) that scores how well you operate Claude Code, Codex, and Grok CLI from your own session transcripts, plus a controlled-run assessment suite with a hidden verifier. No model calls in review mode, nothing uploaded.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
Local-first CLI that scores how well a person operates Claude Code, Codex, and Grok CLI sessions from their own transcripts, plus a controlled-run assessment suite. No model calls in review mode, nothing uploaded.