### PR TITLE
Add Omen

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [Omen](https://github.com/panbanda/omen) - Code-health CLI and MCP server for AI coding agents: complexity, tech debt, dead code, churn hotspots, clones and a health score across ten languages.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
Adds https://github.com/panbanda/omen to Command Line Tools.

Omen is a Rust CLI and MCP server that measures code health for AI coding agents: cyclomatic and cognitive complexity, self-admitted tech debt, stubs, dead code, git churn and hotspots, clone detection, defect prediction, semantic search and a composite health score across Go, Rust, Python, TypeScript, JavaScript, Java, C, C++, C#, Ruby, PHP and Bash. It ships Claude Code plugins (omen-development, omen-reporting) and a GitHub Action for PR risk comments. Apache-2.0, released weekly, installs with Homebrew or Docker. https://github.com/panbanda/omen It fits this list because it exists to give coding agents measured context about a codebase, which is where vibe-coded projects usually lose control.