### PR TITLE
Add ClawMetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) - Open-source version of Bolt.new with Electron desktop apps, 19+ AI providers, and local model support via Ollama.
 - [Superset](https://github.com/superset-sh/superset) - Desktop app to orchestrate multiple AI coding agents in parallel (Claude Code, Codex, etc.) with Git worktree isolation.
 - [Parallel Code](https://github.com/johannesjo/parallel-code) - Desktop app for running multiple AI coding agents (Claude Code, Codex CLI, Gemini CLI) simultaneously in isolated git worktrees.
+- [ClawMetry](https://github.com/vivekchand/clawmetry) - Local dashboard and opt-in kill switch for coding agents (Claude Code, Codex, Cursor, Gemini CLI, OpenClaw) that reads the session logs they already write on disk, so there is no SDK and nothing in the request path. [Website](https://clawmetry.com)
 
 ## Command Line Tools
 


### PR DESCRIPTION
Adds [ClawMetry](https://github.com/vivekchand/clawmetry) ([website](https://clawmetry.com)) to Local Apps, at the bottom of the category per CONTRIBUTING.

Why it fits: it is a local app for people running Claude Code, Codex, Cursor, Gemini CLI or OpenClaw. It reads the session logs those runtimes already write on disk and shows sessions, transcripts, tool calls, tokens and cache-aware cost, with an opt-in emergency stop per session and pre-tool approvals. No SDK, nothing in the request path, nothing leaves the machine by default. `pip install clawmetry && clawmetry`.

Disclosure: I maintain it. OpenClaw and NemoClaw are free in the open-source app; the other runtimes need ClawMetry Cloud or a self-hosted Pro license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rt5fq2BWxieLpR69MAbwjr