### PR TITLE
Add ENZO

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Emergent](https://emergent.sh/) - Multi-agent AI app builder that plans, codes, tests, and deploys full-stack web and mobile apps autonomously.
 - [Manus](https://manus.im/) - Autonomous AI agent for end-to-end project automation, from research to deployment.
 - [Same.new](https://same.new/) - AI web builder for cloning and creating websites from descriptions.
+- [ENZO](https://enzo-hub.duckdns.org) - Self-hosted AI workspace that generates full-stack web apps from prompts and automates Gmail/Calendar workflows, running entirely on your own provider API keys (BYOK). Open source, Apache-2.0.
 
 ## IDEs and Code Editors
 


### PR DESCRIPTION
Adds [ENZO](https://enzo-hub.duckdns.org) to Browser-based Tools.

ENZO is a self-hosted, open-source (Apache-2.0) AI workspace:

- **Generates full-stack web apps from a prompt** — like the other browser-based tools in this section, but self-hosted on your own server (Docker one-liner: `ghcr.io/theguysudo/enzo`, or Node.js).
- **BYOK**: runs entirely on the user's own provider API keys (OpenRouter, Groq, Gemini, NVIDIA…) — every request goes from the browser through your own instance to the provider you pick, no middleman.
- Agents also automate Gmail/Calendar workflows (e.g. "scan my unread Gmail and draft replies").

Repo: https://github.com/theguysudo/ENZO — added at the bottom of the Browser-based Tools category, following the `- [Resource Name](link) - Description.` format from the contribution guidelines.