### PR TITLE
Add Moku to Mobile Apps

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -64,6 +64,7 @@
 
 ## 移动应用
 
+- [Moku](https://github.com/wilsen0/moku) - 专为 AI 编程打造的跨平台终端工作区，一键续接远端 Claude Code、Codex、OpenCode 等会话，自研 Rust 终端核心与 iOS 灵动岛监控。
 - [VibeCode](https://www.vibecodeapp.com/) - 构建应用的应用。适用于iOS和Android。
 
 ## 插件和扩展

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 
 ## Mobile Apps
 
+- [Moku](https://github.com/wilsen0/moku) - A cross-platform terminal workspace built to resume remote AI coding sessions (Claude Code, Codex, OpenCode) in 1 tap, with custom Rust terminal core, Mosh roaming, and iOS Dynamic Island status tracking.
 - [VibeCode](https://www.vibecodeapp.com/) - The app that builds apps. Available on iOS and Android.
 
 ## Plugins and Extensions


### PR DESCRIPTION
### Description

Adds [Moku](https://github.com/wilsen0/moku) to the **Mobile Apps** section in both English and Chinese READMEs.

**Moku** is a cross-platform mobile & desktop terminal workspace designed specifically for vibe coding. It automatically scans remote development hosts for Claude Code, Codex, and OpenCode projects and sessions, allowing developers to resume context in 1 tap from their phone with a custom Rust terminal core (28 MB/s ANSI throughput), native Mosh roaming (no dropped sessions), and iOS Dynamic Island status monitoring.