### PR TITLE
Add YYLO to Command Line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [OpenCode](https://opencode.ai/) - Open-source AI coding agent for the terminal with LSP support, 75+ LLM providers, and multi-session workflows.
 - [onWatch](https://github.com/onllm-dev/onwatch) - Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, MiniMax, and more). Works with Claude Code, Codex CLI, Cursor, Cline, and other vibe coding tools. Background daemon, <50MB RAM, zero telemetry.
 - [pyscn](https://github.com/ludo-technologies/pyscn) - Code quality analyzer for vibe-coded Python. Detects dead code, clones, complexity issues, and coupling problems with MCP integration for AI assistants.
+- [YYLO](https://github.com/yylo-dev/yylo) - Command-line orchestrator for coding agents with typed task, validation, merge, and release-readiness boundaries; each task runs in a dedicated branch/worktree and the merge queue owns risk-based review. MIT, on npm as @yylo/cli.
 
 ## Task Management for AI Coding
 


### PR DESCRIPTION
## Summary

Adds [YYLO](https://github.com/yylo-dev/yylo) to the **Command Line Tools** section, at the bottom per the contribution guidelines.

YYLO is a command-line orchestrator for coding agents, repeatable workflows, and receipt-backed repository changes — each task runs in a dedicated branch/worktree, and the merge queue owns risk-based review. MIT-licensed, on npm as [`@yylo/cli`](https://www.npmjs.com/package/@yylo/cli), actively developed with near-daily pushes (57★).

## Why it fits

Command Line Tools already houses the agents and tools YYLO works alongside (Claude Code, aider, goose, OpenHands, Plandex, OpenAI Codex CLI, Gemini CLI, OpenCode). YYLO's angle is the orchestration layer around such agents: typed task, validation, merge, and release-readiness boundaries, worktree isolation per task, and a risk-based merge queue with receipts.

Single line appended at the section bottom, matching the shape of recent merged additions (#106, #95, #91 — each +1/−0 on README.md only). I only touched the English README; the language mirrors are left to the maintainer-side flow.

## Validation

- Follows the guideline format `- [Resource Name](link) - Description.`, bottom of the relevant category, individual PR, no trailing whitespace.
- Checked for duplicates — no existing entry covering task/merge governance orchestration for coding agents.

## Disclosure

I am on the team that builds YYLO; this PR and the entry text were prepared with AI-agent assistance and reviewed by me. Happy to adjust wording or re-file to another section if preferred.