### PR TITLE
Add ContextStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [EnzeD/vibe-coding](https://github.com/EnzeD/vibe-coding) - The Ultimate Guide to Vibe Coding with best practices and tips.
 - [Claude Code Organizer](https://github.com/mcpware/claude-code-organizer) - Visual dashboard and MCP server to organize Claude Code memories, skills, MCP servers, and hooks with scope hierarchy and drag-and-drop.
 - 🔥 [getdesign.md](https://getdesign.md/) - Browsable library of DESIGN.md files curated from real websites.
+- [ContextStream](https://contextstream.io) - Shared project context for Cursor, Claude Code, Codex, and Grok. Intelligence isn’t the bottleneck. Context is. MCP: https://mcp.contextstream.io/mcp. Benchmarks: https://contextstream.io/benchmarks.
 
 ## Communities & Job Boards
 


### PR DESCRIPTION
Add [ContextStream](https://contextstream.io) to Documentation for AI Coding.

Shared project context for Cursor, Claude Code, Codex, and Grok. Intelligence isn’t the bottleneck. Context is.

- Site: https://contextstream.io
- MCP: https://mcp.contextstream.io/mcp
- Benchmarks: https://contextstream.io/benchmarks

I work on ContextStream.