### PR TITLE
Add CloneAny

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 - [Claude Code Organizer](https://github.com/mcpware/claude-code-organizer) - Visual dashboard and MCP server to organize Claude Code memories, skills, MCP servers, and hooks with scope hierarchy and drag-and-drop.
 - 🔥 [getdesign.md](https://getdesign.md/) - Browsable library of DESIGN.md files curated from real websites.
 
+- [CloneAny](https://cloneany.com/design-md-generator) - Extracts DESIGN.md from a public webpage for use as design context in AI coding agents.
+
 ## Communities & Job Boards
 
 - [Vibehackers](https://vibehackers.io) - Community gallery for vibe coded projects and curated job board.


### PR DESCRIPTION
Adds [CloneAny](https://cloneany.com/design-md-generator) to Documentation for AI Coding. It extracts a DESIGN.md from a public webpage so developers can give coding agents design context from a page they choose. A Tailwind CSS v4 project is available from the same capture.

The scope is one public page, not recursive site cloning. Extraction is deterministic; the tool does not use AI to invent the design values. Public examples: https://cloneany.com/gallery

Disclosure: I am submitting my own product. I checked existing suggestions and placed the entry at the bottom of the relevant category.