### PR TITLE
Add VibeHacker

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ English | [Português](./README-PT.md) | [한국어](./README-KR.md) | [中文](
 ## Communities & Job Boards
 
 - [Vibehackers](https://vibehackers.io) - Community gallery for vibe coded projects and curated job board.
+- [VibeHacker](https://vibehacker.com) - Product discovery community for AI builders and vibe coders: directory, reviews, discussions, and launches.
 - [/r/vibecoding](https://www.reddit.com/r/vibecoding/)
 - [/r/ChatGPTCoding](https://www.reddit.com/r/ChatGPTCoding/)
 - [Vibe Coding Forem](https://vibe.forem.com/) - Community forum for AI-assisted development discussions.


### PR DESCRIPTION
## What
Add [VibeHacker](https://vibehacker.com) — a product discovery community for AI builders and vibe coders (directory, reviews, discussions, launches).

## Why
Fits the communities / discovery section. Distinct from [vibehackers.io](https://vibehackers.io) (build-in-public gallery), which may already be listed.

## Checklist
- [x] Added in the relevant category
- [x] Format matches existing entries
- [x] Spelling/grammar checked